### PR TITLE
Fixes #29 - Provide context menu for discover mode

### DIFF
--- a/README.org
+++ b/README.org
@@ -19,6 +19,14 @@ Then, require it and go.
 I'll make mastdon.el available on MELPA when I feel like it's reached a
 stable state.
 
+Mastodon mode provides a overview of it's shortcuts through [[https://github.com/mickeynp/discover.el][Discover mode]].
+To activate Discover mode locally for Mastodon mode buffers add this to your emacs configuration:
+#+BEGIN_SRC emacs-lisp
+    (add-hook 'mastodon-mode-hook 'discover-mode-turn-on)
+#+END_SRC
+
+The context menu is then activated by pressing '?'.
+
 ** Usage
 
 *** Instance
@@ -54,6 +62,8 @@ Opens a =*mastodon-home*= buffer in the major mode so you can see toots. Keybind
 | =Q= | Quit mastodon buffer and kill window.    |
 | =T= | Prompt for tag and open its timeline     |
 |-----+------------------------------------------|
+
+
 
 *** Toot toot
 

--- a/lisp/mastodon-tl.el
+++ b/lisp/mastodon-tl.el
@@ -42,6 +42,27 @@
   '((t (:foreground "cyan")))
   "Mastodon user handle face.")
 
+(defun mastodon-tl--get-federated-timeline ()
+  "Opens federated timeline."
+  (interactive)
+  (mastodon-tl--get "public"))
+
+(defun mastodon-tl--get-home-timeline ()
+  "Opens home timeline."
+  (interactive)
+  (mastodon-tl--get "home"))
+
+(defun mastodon-tl--get-local-timeline ()
+  "Opens local timeline."
+  (interactive)
+  (mastodon-tl--get "public?local=true"))
+
+(defun mastodon-tl--get-tag-timeline ()
+  "Prompts for tag and opens its timeline."
+  (interactive)
+  (let ((tag (read-string "Tag: ")))
+    (mastodon-tl--get (concat "tag/" tag))))
+
 (defun mastodon-tl--from-toot (key toot)
   "Return value for KEY in TOOT."
   (cdr (assoc key toot)))


### PR DESCRIPTION
* provides a `discover.el` context menu
* moves lambdas from keymap to functions so `discover-my-major` can pick
  them up