### PR TITLE
Close #29 with discover context menu

### DIFF
--- a/README.org
+++ b/README.org
@@ -16,16 +16,21 @@ Then, require it and go.
     (require 'mastodon)
 #+END_SRC
 
+*** use-package
+
+#+BEGIN_SRC emacs-lisp
+  (use-package mastodon
+    :load-path "/path/to/mastodon.el/lisp")
+#+END_SRC
+
+*** MELPA
 I'll make mastdon.el available on MELPA when I feel like it's reached a
 stable state.
 
-Mastodon mode provides a overview of it's shortcuts through [[https://github.com/mickeynp/discover.el][Discover mode]].
-To activate Discover mode locally for Mastodon mode buffers add this to your emacs configuration:
-#+BEGIN_SRC emacs-lisp
-    (add-hook 'mastodon-mode-hook 'discover-mode-turn-on)
-#+END_SRC
+*** Discover
 
-The context menu is then activated by pressing '?'.
+=mastodon-mode= will provide a context menu for its keybindings if =discover=
+is installed. It is not required.
 
 ** Usage
 
@@ -51,19 +56,18 @@ This value can be customized too, and defaults to
 
 Opens a =*mastodon-home*= buffer in the major mode so you can see toots. Keybindings:
 
-|-----+------------------------------------------|
-| Key | Action                                   |
-|-----+------------------------------------------|
-| =F= | Open federated timeline                  |
-| =H= | Open home timeline                       |
-| =L= | Open local timeline                      |
-| =n= | Switch to =mastodon-toot= buffer         |
-| =q= | Quit mastodon buffer. Leave window open. |
-| =Q= | Quit mastodon buffer and kill window.    |
-| =T= | Prompt for tag and open its timeline     |
-|-----+------------------------------------------|
-
-
+|-----+------------------------------------------------|
+| Key | Action                                         |
+|-----+------------------------------------------------|
+| =?= | Open context menu (if =discover= is available) |
+| =F= | Open federated timeline                        |
+| =H= | Open home timeline                             |
+| =L= | Open local timeline                            |
+| =n= | Switch to =mastodon-toot= buffer               |
+| =q= | Quit mastodon buffer. Leave window open.       |
+| =Q= | Quit mastodon buffer and kill window.          |
+| =T= | Prompt for tag and open its timeline           |
+|-----+------------------------------------------------|
 
 *** Toot toot
 

--- a/README.org
+++ b/README.org
@@ -19,6 +19,14 @@ Then, require it and go.
 I'll make mastdon.el available on MELPA when I feel like it's reached a
 stable state.
 
+Mastodon mode provides a overview of it's shortcuts through [[https://github.com/mickeynp/discover.el][Discover mode]].
+To activate Discover mode locally for Mastodon mode buffers add this to your emacs configuration:
+#+BEGIN_SRC emacs-lisp
+    (add-hook 'mastodon-mode-hook 'discover-mode-turn-on)
+#+END_SRC
+
+The context menu is then activated by pressing '?'.
+
 ** Usage
 
 *** Instance
@@ -54,6 +62,8 @@ Opens a =*mastodon-home*= buffer in the major mode so you can see toots. Keybind
 | =Q= | Quit mastodon buffer and kill window.    |
 | =T= | Prompt for tag and open its timeline     |
 |-----+------------------------------------------|
+
+
 
 *** Toot toot
 

--- a/lisp/mastodon-tl.el
+++ b/lisp/mastodon-tl.el
@@ -42,6 +42,27 @@
   '((t (:foreground "cyan")))
   "Mastodon user handle face.")
 
+(defun mastodon-tl--get-federated-timeline ()
+  "Opens federated timeline."
+  (interactive)
+  (mastodon-tl--get "public"))
+
+(defun mastodon-tl--get-home-timeline ()
+  "Opens home timeline."
+  (interactive)
+  (mastodon-tl--get "home"))
+
+(defun mastodon-tl--get-local-timeline ()
+  "Opens local timeline."
+  (interactive)
+  (mastodon-tl--get "public?local=true"))
+
+(defun mastodon-tl--get-tag-timeline ()
+  "Prompts for tag and opens its timeline."
+  (interactive)
+  (let ((tag (read-string "Tag: ")))
+    (mastodon-tl--get (concat "tag/" tag))))
+
 (defun mastodon-tl--from-toot (key toot)
   "Return value for KEY in TOOT."
   (cdr (assoc key toot)))

--- a/lisp/mastodon.el
+++ b/lisp/mastodon.el
@@ -102,10 +102,8 @@
     (define-key map (kbd "Q") #'kill-buffer-and-window)
     (define-key map (kbd "T") #'mastodon-tl--get-tag-timeline)))
 
-(defun provide-discover-context-menu ()
-  "Provides a shortcut overview through Discover mode.
-Press '?' to activate it."
-  (when (bound-and-true-p discover-mode)
+(with-eval-after-load 'mastodon
+  (when (require 'discover nil :noerror)
     (discover-add-context-menu
      :bind "?"
      :mode 'mastodon-mode
@@ -123,8 +121,6 @@ Press '?' to activate it."
                       ("Quit"
                        ("q" "Quit mastodon buffer. Leave window open." kill-this-buffer)
                        ("Q" "Quit mastodon buffer and kill window." kill-buffer-and-window)))))))
-
-(add-hook 'mastodon-mode-hook 'provide-discover-context-menu t)
 
 (provide 'mastodon)
 ;;; mastodon.el ends here


### PR DESCRIPTION
Add a context-menu from the `discover` package if `discover` can be required. 
Bind menu to `?` in `mastodon-mode`.

Close #30 as well, since its commit was cherry-picked into this PR.