### PR TITLE
Add boost feature to timelines

### DIFF
--- a/README.org
+++ b/README.org
@@ -54,12 +54,15 @@ This value can be customized too, and defaults to
 
 =M-x mastodon=
 
-Opens a =*mastodon-home*= buffer in the major mode so you can see toots. Keybindings:
+Opens a =*mastodon-home*= buffer in the major mode so you can see toots.
+
+**** Keybindings
 
 |-----+------------------------------------------------|
 | Key | Action                                         |
 |-----+------------------------------------------------|
 | =?= | Open context menu (if =discover= is available) |
+| =b= | Boost toot under =point=                       |
 | =F= | Open federated timeline                        |
 | =H= | Open home timeline                             |
 | =j= | Go to next toot                                |
@@ -70,6 +73,14 @@ Opens a =*mastodon-home*= buffer in the major mode so you can see toots. Keybind
 | =Q= | Quit mastodon buffer and kill window.          |
 | =T= | Prompt for tag and open its timeline           |
 |-----+------------------------------------------------|
+
+**** Legend
+
+|--------+----------------------|
+| Marker | Meaning              |
+|--------+----------------------|
+| =(B)=  | I boosted this toot. |
+|--------+----------------------|
 
 *** Toot toot
 

--- a/lisp/mastodon-http.el
+++ b/lisp/mastodon-http.el
@@ -108,6 +108,25 @@ If response code is not 2XX, switches to the response buffer created by `url-ret
       (funcall success)
     (switch-to-buffer (current-buffer))))
 
+(defun mastodon-http--post (url args headers)
+  "POST synchronously to URL with ARGS and HEADERS.
+
+Authorization header is included by default."
+  (let ((url-request-method "POST")
+        (url-request-data
+         (when args
+           (mapconcat (lambda (arg)
+                        (concat (url-hexify-string (car arg))
+                                "="
+                                (url-hexify-string (cdr arg))))
+                      args
+                      "&")))
+        (url-request-extra-headers
+         `(("Authorization" . ,(concat "Bearer " (mastodon--access-token)))
+           ,headers)))
+    (with-temp-buffer
+      (url-retrieve-synchronously url))))
+
 (defun mastodon-http--get (url)
   "Make GET request to URL.
 

--- a/lisp/mastodon-tl.el
+++ b/lisp/mastodon-tl.el
@@ -107,9 +107,14 @@
        (mastodon-tl--byline-author reblog)))))
 
 (defun mastodon-tl--byline (toot)
-  (let ((id (cdr (assoc 'id toot))))
+  (let ((id (cdr (assoc 'id toot)))
+        (boosted (or (cdr (assoc 'reblogged toot))
+                     (cdr (assoc 'reblogged
+                                 (cdr (assoc 'reblog toot)))))))
     (propertize
      (concat (propertize "\n | " 'face 'default)
+             (when boosted
+               (format "(%s) " (propertize "B" 'face 'success)))
              (mastodon-tl--byline-author toot)
              (mastodon-tl--byline-boosted toot)
              (propertize "\n  ------------" 'face 'default))

--- a/lisp/mastodon-tl.el
+++ b/lisp/mastodon-tl.el
@@ -145,11 +145,17 @@
                                         (number-to-string id)))))
     (mastodon-http--get-json url)))
 
+(defun mastodon-tl--property (prop)
+  "Get property PROP for toot at point."
+  (or (get-text-property (point) prop)
+      (progn
+        (mastodon-tl--goto-next-toot)
+        (get-text-property (point) prop))))
+
 (defun mastodon-tl--newest-id ()
   "Return toot-id from the top of the buffer."
   (goto-char (point-min))
-  (mastodon-tl--goto-next-toot)
-  (get-text-property (point) 'toot-id))
+  (mastodon-tl--property 'toot-id))
 
 (defun mastodon-tl--update ()
   "Update timeline with new toots."

--- a/lisp/mastodon-toot.el
+++ b/lisp/mastodon-toot.el
@@ -61,6 +61,27 @@ STATUS is passed by `url-retrieve'."
   (interactive)
   (kill-buffer-and-window))
 
+(defun mastodon-toot--property (prop)
+  "Get property PROP for toot at point."
+  (or (get-text-property (point) prop)
+      (progn
+        (mastodon-tl--goto-next-toot)
+        (get-text-property (point) prop))))
+
+;; TODO extract success callback
+(defun mastodon-toot--boost ()
+  "Boost toot at point."
+  (interactive)
+  (let* ((id (mastodon-toot--property 'toot-id))
+         (url (mastodon--api-for (concat "statuses/"
+                                         (number-to-string id)
+                                         "/reblog"))))
+    (let ((response (mastodon-http--post url nil nil)))
+      (with-current-buffer response
+        (if (string-prefix-p "2" (mastodon--response-code))
+            (message "Boosted!")
+          (switch-to-buffer response))))))
+
 (defvar mastodon-toot-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "C-c C-c") #'mastodon-toot-send)

--- a/lisp/mastodon-toot.el
+++ b/lisp/mastodon-toot.el
@@ -61,18 +61,11 @@ STATUS is passed by `url-retrieve'."
   (interactive)
   (kill-buffer-and-window))
 
-(defun mastodon-toot--property (prop)
-  "Get property PROP for toot at point."
-  (or (get-text-property (point) prop)
-      (progn
-        (mastodon-tl--goto-next-toot)
-        (get-text-property (point) prop))))
-
 ;; TODO extract success callback
 (defun mastodon-toot--boost ()
   "Boost toot at point."
   (interactive)
-  (let* ((id (mastodon-toot--property 'toot-id))
+  (let* ((id (mastodon-tl--property 'toot-id))
          (url (mastodon--api-for (concat "statuses/"
                                          (number-to-string id)
                                          "/reblog"))))

--- a/lisp/mastodon.el
+++ b/lisp/mastodon.el
@@ -94,6 +94,7 @@
   "Major mode for Mastodon, the federated microblogging network."
   :group 'mastodon
   (let ((map mastodon-mode-map))
+    (define-key map (kbd "b") #'mastodon-toot--boost)
     (define-key map (kbd "F") #'mastodon-tl--get-federated-timeline)
     (define-key map (kbd "H") #'mastodon-tl--get-home-timeline)
     (define-key map (kbd "j") #'mastodon-tl--goto-next-toot)
@@ -115,6 +116,7 @@
                      (description "Mastodon feed viewer")
                      (actions
                       ("Toots"
+                       ("b" "Boost" mastodon-toot--boost)
                        ("j" "Next" mastodon-tl--goto-next-toot)
                        ("k" "Prev" mastodon-tl--goto-prev-toot)
                        ("n" "Send" mastodon-toot)


### PR DESCRIPTION
Work toward #16:

* Add boost function
* Bind boost function to `b` in timelines
* Insert marker `(B)` in byline after boost
* Read boosted state from API and persist `(B)` marker on subsequent timeline loads

The `B` in the `(B)` marker is propertized with `'face 'success`.