### PR TITLE
Better POST callbacks

### DIFF
--- a/lisp/mastodon-http.el
+++ b/lisp/mastodon-http.el
@@ -39,7 +39,9 @@
   (concat mastodon-instance-url "/api/" mastodon--api-version "/" endpoint))
 
 (defun mastodon--http-post (url callback args &optional headers)
-  "Make POST request to URL.
+  "This function should be phased out in favor of `mastodon-http--post'.
+
+Make POST request to URL.
 
 Response buffer is passed to CALLBACK function.
 ARGS and HEADERS alist arguments are part of the POST request."

--- a/lisp/mastodon-http.el
+++ b/lisp/mastodon-http.el
@@ -108,6 +108,13 @@ If response code is not 2XX, switches to the response buffer created by `url-ret
       (funcall success)
     (switch-to-buffer (current-buffer))))
 
+(defun mastodon-http--triage (response success)
+  (let ((status (with-current-buffer response
+                  (mastodon--response-code))))
+    (if (string-prefix-p "2" status)
+        (funcall success)
+      (switch-to-buffer response))))
+
 (defun mastodon-http--post (url args headers)
   "POST synchronously to URL with ARGS and HEADERS.
 


### PR DESCRIPTION
No more opening to an HTTP response buffer on POST.

* Boosts message `Boosted #12345`
* Favourites message `Favourited #12345`
* New toots and replies message `Toot toot!`