### PR TITLE
Fix #32

### DIFF
--- a/README.org
+++ b/README.org
@@ -103,6 +103,45 @@ Authentication stores your access token in the
 filesystem, so
 you will have to re-authenticate when you close/reopen Emacs.
 
+** Enabling Emojis
+By default no emojis will appear in any of the posts or user names. In order to enable emojis you can install the `emojify` package.
+
+Add [[http://melpa.org/#/emojify][MELPA]] to your list of package archives
+#+BEGIN_SRC elisp
+(require 'package)
+(add-to-list 'package-archives ("melpa" . "https://melpa.org/packages/") t)
+(package-initialize)
+#+END_SRC
+
+Update the contents of your package archive and download `emojify`
+
+This only needs to be called once. i.e. you should not put it in your `.emacs` or `init.el` file.
+#+BEGIN_SRC elisp
+(package-refresh-contents)
+(package-install 'emojify)
+#+END_SRC
+
+If you would rather install `emojify` interactively you can do so by doing the following.
+
+Refresh the package index
+#+BEGIN_QUOTE
+M-x package-refresh-contents RET
+#+END_QUOTE
+
+And then install it by doing
+#+BEGIN_QUOTE
+M-x package-install RET emojify
+#+END_QUOTE
+
+Once installed you can define a hook for `mastodon-mode` that call  `emojify-mode`
+#+BEGIN_SRC elisp
+(require 'emojify)
+(defun my-mastodon-hook-function ()
+  (emojify-mode 't))
+(add-hook 'mastodon-mode-hook 'my-mastodon-hook-function)
+#+END_SRC
+
+
 ** Roadmap
 
 [[https://github.com/jdenen/mastodon.el/milestone/1][Here]] are the features I plan to implement before putting mastodon.el on MELPA.

--- a/lisp/mastodon-tl.el
+++ b/lisp/mastodon-tl.el
@@ -89,8 +89,11 @@
 (defun mastodon-tl--byline-author (toot)
   "Propertize author of TOOT."
   (let* ((account (cdr (assoc 'account toot)))
-         (handle (cdr (assoc 'acct account)))
-         (name (cdr (assoc 'display_name account))))
+	 ;; It may not be necissary to decode the handle
+         (handle (decode-coding-string
+		  (cdr (assoc 'acct account))'utf-8))
+	 (name (decode-coding-string
+		(cdr (assoc 'display_name account)) 'utf-8)))
     (concat
      (propertize name 'face 'warning)
      " (@"
@@ -134,7 +137,7 @@ Return value from boosted content if available."
   "Retrieve text content from TOOT."
   (let ((content (mastodon-tl--field 'content toot)))
     (propertize (with-temp-buffer
-                  (insert content)
+                  (insert (decode-coding-string content 'utf-8))
                   (shr-render-region (point-min) (point-max))
                   (buffer-string))
                 'face 'default)))


### PR DESCRIPTION
1. Added `decode-coding-string` in `mastodon-tl--byline-author` and `mastodon-tl--content`
      - This will fix special characters, turning  `\303\251ve` into `éve`.

2. Added instructions on how to enable emojis in emacs
      - This relies on `emojify`, which is a rather large package.

The results on my machine look like this
![screenshot 2017-04-22 15 48 45](https://cloud.githubusercontent.com/assets/6475397/25307693/39b62dd2-2773-11e7-988e-31633d546641.png)