### PR TITLE
Add function to get older toots

### DIFF
--- a/test/ert-helper.el
+++ b/test/ert-helper.el
@@ -3,4 +3,5 @@
 (load-file "lisp/mastodon-auth.el")
 (load-file "lisp/mastodon-toot.el")
 (load-file "lisp/mastodon-tl.el")
+(load-file "lisp/mastodon.el")
 

--- a/test/mastodon-tl-tests.el
+++ b/test/mastodon-tl-tests.el
@@ -9,3 +9,10 @@
   "Should replace <\p> tags with two new lines."
   (let ((input "foobar</p>"))
     (should (string= (mastodon-tl--remove-html input) "foobar\n\n"))))
+
+(ert-deftest more-json ()
+  "Should request toots older than max_id."
+  (let ((mastodon-instance-url "https://instance.url"))
+    (with-mock
+      (mock (mastodon-http--get-json "https://instance.url/api/v1/timelines/foo?max_id=12345"))
+      (mastodon-tl--more-json "foo" 12345))))


### PR DESCRIPTION
You can request more toots by hitting `j` at the end of a timeline buffer.