### PR TITLE
Partial fix #41

### DIFF
--- a/lisp/mastodon-tl.el
+++ b/lisp/mastodon-tl.el
@@ -140,6 +140,44 @@ Return value from boosted content if available."
      'toot-id id
      'toot-json toot)))
 
+
+(defun mastodon-tl--set-face (string face render)
+  "Set the face of a string. If `render` is not 'nil
+also render the html"
+  (propertize
+   (with-temp-buffer
+     (insert (decode-coding-string string 'utf-8))
+     (when render
+       (shr-render-region (point-min) (point-max)))
+     (buffer-string))
+   'face face))
+       
+(defun mastodon-tl--spoiler (toot)
+  "Retrieve spoiler message from TOOT."
+  (let* ((spoiler (mastodon-tl--field 'spoiler_text toot))
+	 (string (mastodon-tl--set-face spoiler 'default t))
+	 (message (concat "\n ---------------"
+			  "\n Content Warning"
+			  "\n ---------------\n"))
+	 (cw (mastodon-tl--set-face message 'success 'nil)))
+    (if (> (length string) 0)
+	(replace-regexp-in-string "\n\n\n ---------------"
+				  "\n ---------------" (concat string cw))
+      "")))
+
+
+(defun mastodon-tl--media (toot)
+  "Retreive a media attachment link if one exits"
+  (let ((media (mastodon-tl--field 'media_attachments toot)))
+    (if(> (length media) 0 )
+	;; Extract the preview_url, other options here
+	;; are url and remote_url
+	(let ((link (cdr(assoc 'preview_url (elt media 0)))))
+	  (concat "Media_Link:: "
+		  (mastodon-tl--set-face link 'mouse-face 'nil)))
+      ;; Otherwise return an empty string
+      "")))
+
 (defun mastodon-tl--content (toot)
   "Retrieve text content from TOOT."
   (let ((content (mastodon-tl--field 'content toot)))
@@ -152,7 +190,9 @@ Return value from boosted content if available."
 (defun mastodon-tl--toot (toot)
   (insert
    (concat
+    (mastodon-tl--spoiler toot)
     (mastodon-tl--content toot)
+    (mastodon-tl--media toot)
     (mastodon-tl--byline toot)
     "\n\n")))
 


### PR DESCRIPTION
I have added inline media links and content warnings.

1. Media Links
    - currently the media links are displayed below the content of the toot. To view the link you can use `M-x ffap RET`
    - I have a prototype for inline images, but currently it is very buggy and slows down page loading considerably
    - Note: When the server can't find the requested image it returns a default string. This default string should be detected and return a local image that is distributed with the package

 2. Content warnings
    - The content warnings now appears above their toots. 
    - Currently there is no folding, however it could be implemented using something like hideshow

