### PR TITLE
Fixed #65 pointer placement when getting more toots

### DIFF
--- a/lisp/mastodon-tl.el
+++ b/lisp/mastodon-tl.el
@@ -217,14 +217,17 @@ Return value from boosted content if available."
 (defun mastodon-tl--more ()
   "Append older toots to timeline."
   (interactive)
-  (let* ((tl (mastodon-tl--timeline-name))
+  (let* ((point-before-update (point))
+	 (tl (mastodon-tl--timeline-name))
          (id (mastodon-tl--oldest-id))
          (json (mastodon-tl--more-json tl id)))
     (when json
       (with-current-buffer (current-buffer)
         (let ((inhibit-read-only t))
           (goto-char (point-max))
-          (mastodon-tl--timeline json))))))
+          (mastodon-tl--timeline json)
+	  (goto-char point-before-update)
+	  (mastodon-tl--goto-next-toot))))))
 
 (defun mastodon-tl--update ()
   "Update timeline with new toots."

--- a/lisp/mastodon-tl.el
+++ b/lisp/mastodon-tl.el
@@ -217,7 +217,7 @@ Return value from boosted content if available."
 (defun mastodon-tl--more ()
   "Append older toots to timeline."
   (interactive)
-  (let* ((point-before-update (point))
+  (let* ((point-before (point))
 	 (tl (mastodon-tl--timeline-name))
          (id (mastodon-tl--oldest-id))
          (json (mastodon-tl--more-json tl id)))
@@ -226,7 +226,7 @@ Return value from boosted content if available."
         (let ((inhibit-read-only t))
           (goto-char (point-max))
           (mastodon-tl--timeline json)
-	  (goto-char point-before-update)
+	  (goto-char point-before)
 	  (mastodon-tl--goto-next-toot))))))
 
 (defun mastodon-tl--update ()


### PR DESCRIPTION
`Point` will now fall on the newest loaded toot.

If the previous behavior, i.e., `Point` ending at `point-max`, is preferred then we should work this into an option.