### PR TITLE
Use simpler `json-read`

### DIFF
--- a/lisp/mastodon-auth.el
+++ b/lisp/mastodon-auth.el
@@ -58,9 +58,8 @@
     (re-search-forward "^$" nil 'move)
     (let ((json-object-type 'plist)
           (json-key-type 'keyword)
-          (json-array-type 'vector)
-          (json-string (buffer-substring-no-properties (point) (point-max))))
-      (json-read-from-string json-string))))
+          (json-array-type 'vector))
+      (json-read))))
 
 (defun mastodon-auth--access-token ()
   "Return `mastodon-auth--token'.

--- a/lisp/mastodon-client.el
+++ b/lisp/mastodon-client.el
@@ -56,9 +56,8 @@
     (re-search-forward "^$" nil 'move)
     (let ((json-object-type 'plist)
           (json-key-type 'keyword)
-          (json-array-type 'vector)
-          (json-string (buffer-substring-no-properties (point) (point-max))))
-      (json-read-from-string json-string))))
+          (json-array-type 'vector))
+      (json-read))))
 
 (defun mastodon-client--token-file ()
   "Return `mastodon-token-file'."

--- a/lisp/mastodon-http.el
+++ b/lisp/mastodon-http.el
@@ -104,8 +104,7 @@ Pass response buffer to CALLBACK function."
          (with-current-buffer (mastodon-http--get url)
            (goto-char (point-min))
            (re-search-forward "^$" nil 'move)
-           (let ((json-string (buffer-substring-no-properties (point) (point-max))))
-             (json-read-from-string json-string)))))
+           (json-read))))
     json-vector))
 
 (provide 'mastodon-http)


### PR DESCRIPTION
Don't use the pattern `(json-read-from-string (buffer-substring-no-properties (point) (point-max)))` where `(json-read)` will do the same thing but more efficiently.

`json-read-from-string` inserts the argument into a temp buffer and then calls `json-read` on that, i.e. with the old pattern we only consed a lot of temporary memory with no added benefit.