### PR TITLE
#37 Enable notifications

### DIFF
--- a/lisp/mastodon-notifications.el
+++ b/lisp/mastodon-notifications.el
@@ -1,73 +1,161 @@
-;; Notifications
-(require 'mastodon-media)
-(require 'mastodon-http)
+;;; mastodon-tl.el --- HTTP request/response functions for mastodon.el
 
-(defvar mastodon-notifications--types '("mention" "follow" "favourite" "reblog" ))
+;; Copyright (C) 2017 Johnson Denen
+;; Author: Johnson Denen <johnson.denen@gmail.com>
+;; Version: 0.5.4
+;; Homepage: https://github.com/jdenen/mastodon.el
+
+;; This file is not part of GNU Emacs.
+
+;; This file is part of mastodon.el.
+
+;; mastodon.el is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; mastodon.el is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with mastodon.el.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; mastodon-notification.el provides notification functions.
+
+;; todo: - integrate media
+;;       - extend notification types
+;;       - replace `You' with `your_display_name'(@`your_user_name')
+;;       - generalize mastodon-tl--more or rebind it in notifications
+;;         example
+;;       - fix thread access
+;;       - Add keybinding of mastodon-notifications--get to `N'
+
+;; ;; One approach for generalizing the get-more functionality
+;; (defun mastodon-tl--get-more (more-function id-fun goto-fun
+;;                               processing-function)
+;;   "can work for both oldert toots and newest toots"
+;;   (interactive)
+;;   (let* ((tl (mastodon-tl--timeline-name))
+;;	 (id (funcall id-fun))
+;;	 (json (funcall more-function tl id)))
+;;     (when json
+;;       (with-current-buffer (current-buffer)
+;;	(let ((inhibit-read-only t))
+;;	  (goto-char (funcall goto-fun))
+;;	  (funcall processing-function json))))))
+;;
+;; ;; Equivelent to the mastodon-tl--more
+;; (mastodon-tl--get-more 'mastodon-tl--more-json 'mastodon-tl--oldest-id
+;;                        point-max mastodon-tl--timeline)
+;;
+;; ;; Equivelent to the mastodon-tl--update
+;; (mastodon-tl--get-more 'mastodon-tl--update-json 'mastodon-tl--newest-id
+;;                        point-min mastodon-tl--timeline)
+
+
+;;; Code:
+
+;;(require 'mastodon-media)
+(require 'mastodon-http)
+(require 'mastodon-tl)
+
+(defvar mastodon-notifications--types
+  '("mention" "follow" "favourite" "reblog" )
+  "A list of notification types that have been implemented")
+
+(defun mastodon-notifications--byline-concat (toot message)
+  "Add byline for message type from TOOT."
+      (concat
+       " "
+       (propertize message 'face 'highlight)
+       " "
+       "You!"))
+
+(defun mastodon-notifications--byline (toot message)
+  "Generate byline for notification."
+  (let ((id (cdr (assoc 'id toot)))
+	(faved (mastodon-tl--field 'favourited toot))
+	(boosted (mastodon-tl--field 'reblogged toot)))
+    (propertize
+     (concat (propertize "\n | " 'face 'default)
+	     (when boosted
+	       (format "(%s) " (propertize "B" 'face 'success)))
+	     (when faved
+	       (format "(%s) " (propertize "F" 'face 'success)))
+	     (mastodon-tl--byline-author toot)
+	     (mastodon-notifications--byline-concat toot message)
+	     (propertize "\n  ------------" 'face 'default))
+     'toot-id id
+     'toot-json toot)))
 
 (defun mastodon-notifications--mention(note)
-  (let* ((status (mastodon-notifications--field 'status note))
-	 (account (mastodon-notifications--field 'account status))
-	 (spoiler (mastodon-notifications--field 'spoiler_text status))
-	 (content (mastodon-notifications--field 'content status))
-	 (media (mastodon-notifications--field 'media status))
-    )))
+  "Format for a `mention' notification"
+  (let ((toot (mastodon-tl--field 'status note)))
+    (insert
+     (concat (mastodon-tl--content toot)
+	     (mastodon-notifications--byline toot "Mentioned")
+	     "\n\n"))))
 
 (defun mastodon-notifications--follow(note)
-  (let* ((account (mastodon-notifications--field 'account note))
-	 (username (mastodon-notifications--field 'username account))
-	 (display (mastodon-notifications--field 'display account))
-	 ))
-  )
+  "Format for a `follow' notification"
+  (let ((toot (mastodon-tl--field 'status note)))
+  (insert
+   (concat
+    "Congratulations, you have a new follower!"
+    (mastodon-notifications--byline note "Follows")
+    "\n\n"))))
+
 
 (defun mastodon-notifications--favorite(note)
-  "note"
-  )
+  "Format for a `favorite' notification"
+  (let ((toot (mastodon-tl--field 'status note)))
+    (insert
+     (concat (mastodon-tl--content toot)
+	     (mastodon-notifications--byline note "Favorited")
+	     "\n\n"))))
 
 (defun mastodon-notifications--reblog(note)
-  "note"
-  )
+  "Format for a `boost' notification"
+  (let ((toot (mastodon-tl--field 'status note)))
+    (insert
+     (concat (mastodon-tl--content toot)
+	     (mastodon-notifications--byline note "Boosted")
+	     "\n\n"))))
 
 (defun mastodon-notifications--caller (type note)
+  "Calls the apprpriate function bassed on notification type."
   (cond ((equal type "mention") (mastodon-notifications--mention note))
 	((equal type "follow") (mastodon-notifications--follow note))
 	((equal type "favourite") (mastodon-notifications--favorite note))
-	((equal type "reblog") (mastodon-notifications--reblog note))
-	)
-  )
+	((equal type "reblog") (mastodon-notifications--reblog note))))
 
 (defun mastodon-notifications--note (note)
-  (let ((type (mastodon-notifications--field 'type note)))
-    (when (member type mastodon-notifications--types)
-      (insert
-       (concat (mastodon-notifications--caller type note)
-	   "\n")))))
+  "Filters the notifications for those that are listed in
 
+`mastodon-notifications--types'. It then passes the results to the `caller'"
+  (let ((type (mastodon-tl--field 'type note)))
+    (when (member type mastodon-notifications--types)
+      (mastodon-notifications--caller type note))))
 
 (defun mastodon-notifications--notifications (json)
-  (mapcar #'mastodon-notifications--note json)  )
+  "Format json in emacs buffer."
+  (mapcar #'mastodon-notifications--note json)
+  (replace-regexp "\n\n\n | " "\n | " nil (point-min) (point-max)))
 
 (defun mastodon-notifications--get()
+  "Display NOTIFICATIONS in buffer."
+  (interactive)
   (let* ((url (mastodon-http--api "notifications"))
 	 (buffer "*mastodon-notifications*")
-	 (json (mastodon-http--get-json url)))    
+	 (json (mastodon-http--get-json url)))
     (with-output-to-temp-buffer buffer
       (switch-to-buffer buffer)
       (mastodon-notifications--notifications json))
-      (mastodon-mode)
-    ))
+    (mastodon-mode)))
 
-(defun mastodon-notifications--field (field notification)
-  (cdr(assoc field notification)))
-
-
-
-(remove-if-not (lambda (x) (equal "mention" (cdr(second x))))(mastodon-http--get-json (mastodon-http--api "notifications")))
-
-
-(defvar *sample-mention* (elt (remove-if-not (lambda (x) (equal "mention" (cdr(second x))))(mastodon-http--get-json (mastodon-http--api "notifications"))) 0))
-
-(defvar *sample-favorite* (elt (remove-if-not (lambda (x) (equal "favourite" (cdr(second x))))(mastodon-http--get-json (mastodon-http--api "notifications"))) 0))
-
-(defvar *sample-reblog* (elt (remove-if-not (lambda (x) (equal "reblog" (cdr(second x))))(mastodon-http--get-json (mastodon-http--api "notifications"))) 0))
-
-(defvar *sample-follow* (elt (remove-if-not (lambda (x) (equal "follow" (cdr(second x))))(mastodon-http--get-json (mastodon-http--api "notifications"))) 0))
+(provide 'mastodon-tl)
+;;; mastodon-tl.el ends here

--- a/lisp/mastodon-notifications.el
+++ b/lisp/mastodon-notifications.el
@@ -162,7 +162,13 @@ It then processes NOTE."
     (with-output-to-temp-buffer buffer
       (switch-to-buffer buffer)
       (mastodon-notifications--notifications json))
-    (mastodon-mode)))
+    (with-current-buffer buffer
+      (mastodon-mode)
+      (setq mastodon-tl--buffer-spec
+            `(buffer-name "*mastodon-notifications*"
+                          endpoint "notifications"
+                          update-function ,(lambda(x) (message "not implemented")))))
+    ))
 
 (provide 'mastodon-notifications)
 ;;; mastodon-notifications.el ends here

--- a/lisp/mastodon-notifications.el
+++ b/lisp/mastodon-notifications.el
@@ -1,0 +1,73 @@
+;; Notifications
+(require 'mastodon-media)
+(require 'mastodon-http)
+
+(defvar mastodon-notifications--types '("mention" "follow" "favourite" "reblog" ))
+
+(defun mastodon-notifications--mention(note)
+  (let* ((status (mastodon-notifications--field 'status note))
+	 (account (mastodon-notifications--field 'account status))
+	 (spoiler (mastodon-notifications--field 'spoiler_text status))
+	 (content (mastodon-notifications--field 'content status))
+	 (media (mastodon-notifications--field 'media status))
+    )))
+
+(defun mastodon-notifications--follow(note)
+  (let* ((account (mastodon-notifications--field 'account note))
+	 (username (mastodon-notifications--field 'username account))
+	 (display (mastodon-notifications--field 'display account))
+	 ))
+  )
+
+(defun mastodon-notifications--favorite(note)
+  "note"
+  )
+
+(defun mastodon-notifications--reblog(note)
+  "note"
+  )
+
+(defun mastodon-notifications--caller (type note)
+  (cond ((equal type "mention") (mastodon-notifications--mention note))
+	((equal type "follow") (mastodon-notifications--follow note))
+	((equal type "favourite") (mastodon-notifications--favorite note))
+	((equal type "reblog") (mastodon-notifications--reblog note))
+	)
+  )
+
+(defun mastodon-notifications--note (note)
+  (let ((type (mastodon-notifications--field 'type note)))
+    (when (member type mastodon-notifications--types)
+      (insert
+       (concat (mastodon-notifications--caller type note)
+	   "\n")))))
+
+
+(defun mastodon-notifications--notifications (json)
+  (mapcar #'mastodon-notifications--note json)  )
+
+(defun mastodon-notifications--get()
+  (let* ((url (mastodon-http--api "notifications"))
+	 (buffer "*mastodon-notifications*")
+	 (json (mastodon-http--get-json url)))    
+    (with-output-to-temp-buffer buffer
+      (switch-to-buffer buffer)
+      (mastodon-notifications--notifications json))
+      (mastodon-mode)
+    ))
+
+(defun mastodon-notifications--field (field notification)
+  (cdr(assoc field notification)))
+
+
+
+(remove-if-not (lambda (x) (equal "mention" (cdr(second x))))(mastodon-http--get-json (mastodon-http--api "notifications")))
+
+
+(defvar *sample-mention* (elt (remove-if-not (lambda (x) (equal "mention" (cdr(second x))))(mastodon-http--get-json (mastodon-http--api "notifications"))) 0))
+
+(defvar *sample-favorite* (elt (remove-if-not (lambda (x) (equal "favourite" (cdr(second x))))(mastodon-http--get-json (mastodon-http--api "notifications"))) 0))
+
+(defvar *sample-reblog* (elt (remove-if-not (lambda (x) (equal "reblog" (cdr(second x))))(mastodon-http--get-json (mastodon-http--api "notifications"))) 0))
+
+(defvar *sample-follow* (elt (remove-if-not (lambda (x) (equal "follow" (cdr(second x))))(mastodon-http--get-json (mastodon-http--api "notifications"))) 0))

--- a/lisp/mastodon-notifications.el
+++ b/lisp/mastodon-notifications.el
@@ -110,7 +110,7 @@
   (let ((toot (mastodon-tl--field 'status note)))
   (insert
    (concat
-    "Congratulations, you have a new follower!"
+    "Congratulations, you have a new follower!\n\n"
     (mastodon-notifications--byline note "Follows")
     "\n\n"))))
 
@@ -150,19 +150,26 @@ It then processes NOTE."
 
 (defun mastodon-notifications--notifications (json)
   "Format JSON in Emacs buffer."
-  (mapcar #'mastodon-notifications--note json)
-  (replace-regexp "\n\n\n | " "\n | " nil (point-min) (point-max)))
+  (mapc #'mastodon-notifications--note json)
+  (goto-char (point-min))
+  (while (search-forward "\n\n\n | " nil t)
+    (replace-match "\n | ")))
 
-(defun mastodon-notifications--get ()
-  "Display NOTIFICATIONS in buffer."
+(defun mastodon-notifications--get()
   (interactive)
-  (let* ((url (mastodon-http--api "notifications"))
-         (buffer "*mastodon-notifications*")
-         (json (mastodon-http--get-json url)))
-    (with-output-to-temp-buffer buffer
-      (switch-to-buffer buffer)
-      (mastodon-notifications--notifications json))
-    (mastodon-mode)))
+  (mastodon-tl--init
+   "notifications" "notifications" 'mastodon-notifications--notifications))
+
+;; (defun mastodon-notifications--get ()
+;;   "Display NOTIFICATIONS in buffer."
+;;   (interactive)
+;;   (let* ((url (mastodon-http--api "notifications"))
+;;          (buffer "*mastodon-notifications*")
+;;          (json (mastodon-http--get-json url)))
+;;     (with-output-to-temp-buffer buffer
+;;       (switch-to-buffer buffer)
+;;       (mastodon-notifications--notifications json))
+;;     (mastodon-mode)))
 
 (provide 'mastodon-notifications)
 ;;; mastodon-notifications.el ends here

--- a/lisp/mastodon-notifications.el
+++ b/lisp/mastodon-notifications.el
@@ -82,35 +82,32 @@
   "Format for a `mention' NOTE."
   (let ((toot (mastodon-tl--field 'status note)))
     (insert
-     (concat (mastodon-tl--content toot)
+     (mastodon-tl--content toot)
              (mastodon-notifications--byline toot "Mentioned")
-             "\n\n"))))
+             "\n\n")))
 
 (defun mastodon-notifications--follow (note)
   "Format for a `follow' NOTE."
   (let ((toot (mastodon-tl--field 'status note)))
     (insert
-     (concat
       "Congratulations, you have a new follower!\n\n"
       (mastodon-notifications--byline note "Follows")
-      "\n\n"))))
+      "\n\n")))
 
 
 (defun mastodon-notifications--favorite(note)
   "Format for a `favorite' NOTE."
   (let ((toot (mastodon-tl--field 'status note)))
-    (insert
      (concat (mastodon-tl--content toot)
              (mastodon-notifications--byline note "Favorited")
-             "\n\n"))))
+             "\n\n")))
 
 (defun mastodon-notifications--reblog (note)
   "Format for a `boost' NOTE."
   (let ((toot (mastodon-tl--field 'status note)))
-    (insert
      (concat (mastodon-tl--content toot)
              (mastodon-notifications--byline note "Boosted")
-             "\n\n"))))
+             "\n\n")))
 
 (defun mastodon-notifications--caller (type note)
   "Call the apprpriate function bassed on notification TYPE.

--- a/lisp/mastodon-tl.el
+++ b/lisp/mastodon-tl.el
@@ -268,6 +268,8 @@ also render the html"
                                      "?")
                                    "max_id="
                                    (number-to-string id)))))
+    (message url)
+    (mastodon-http--get url)
     (mastodon-http--get-json url)))
 
 ;; TODO

--- a/lisp/mastodon-tl.el
+++ b/lisp/mastodon-tl.el
@@ -267,7 +267,9 @@ also render the html"
                                        "&"
                                      "?")
                                    "max_id="
-                                   (number-to-string id)))))
+                                   (if (numberp id )
+                                       (number-to-string id)
+                                     id)))))
     (mastodon-http--get-json url)))
 
 ;; TODO
@@ -280,7 +282,9 @@ also render the html"
                                       "&"
                                     "?")
                                   "since_id="
-                                  (number-to-string id)))))
+                                  (if (numberp id)
+                                      (number-to-string id)
+                                    id)))))
     (mastodon-http--get-json url)))
 
 (defun mastodon-tl--property (prop &optional backward)

--- a/lisp/mastodon.el
+++ b/lisp/mastodon.el
@@ -32,6 +32,7 @@
 ;;; Code:
 (declare-function discover-add-context-menu "discover")
 (declare-function emojify-mode "emojify")
+(autoload 'mastodon-notifications--get "mastodon-notifications")
 (autoload 'mastodon-tl--get-federated-timeline "mastodon-tl")
 (autoload 'mastodon-tl--get-home-timeline "mastodon-tl")
 (autoload 'mastodon-tl--get-local-timeline "mastodon-tl")

--- a/test/mastodon-tl-tests.el
+++ b/test/mastodon-tl-tests.el
@@ -103,6 +103,26 @@
       (mock (mastodon-http--get-json "https://instance.url/api/v1/timelines/foo?max_id=12345"))
       (mastodon-tl--more-json "timelines/foo" 12345))))
 
+(ert-deftest more-json-id-string ()
+  "Should request toots older than max_id.
+
+`mastodon-tl--more-json' should accept and id that is either
+a string or a numeric."
+  (let ((mastodon-instance-url "https://instance.url"))
+    (with-mock
+      (mock (mastodon-http--get-json "https://instance.url/api/v1/timelines/foo?max_id=12345"))
+      (mastodon-tl--more-json "timelines/foo" "12345"))))
+
+(ert-deftest update-json-id-string ()
+  "Should request toots more recent than since_id.
+
+`mastodon-tl--updated-json' should accept and id that is either
+a string or a numeric."  
+  (let ((mastodon-instance-url "https://instance.url"))
+    (with-mock
+      (mock (mastodon-http--get-json "https://instance.url/api/v1/timelines/foo?since_id=12345"))
+      (mastodon-tl--updated-json "timelines/foo" "12345"))))
+
 (ert-deftest mastodon-tl--byline-regular ()
   "Should format the regular toot correctly."
   (let ((mastodon-tl--show-avatars-p nil)

--- a/test/mastodon-tl-tests.el
+++ b/test/mastodon-tl-tests.el
@@ -104,7 +104,6 @@
       (mock (mastodon-http--get-json "https://instance.url/api/v1/timelines/foo?max_id=12345"))
       (mastodon-tl--more-json "timelines/foo" 12345))))
 
-
 (ert-deftest mastodon-tl--relative-time-description ()
   "Should format relative time as expected"
   (cl-labels ((minutes (n) (* n 60))
@@ -225,7 +224,6 @@ a string or a numeric."
       (mock (mastodon-http--get-json "https://instance.url/api/v1/timelines/foo?since_id=12345"))
       (mastodon-tl--updated-json "timelines/foo" "12345"))))
 
-
 (ert-deftest mastodon-tl--byline-regular ()
   "Should format the regular toot correctly."
   (let ((mastodon-tl--show-avatars-p nil)
@@ -282,7 +280,6 @@ a string or a numeric."
                        "
  | (F) Account 42 (@acct42@example.space) 2999-99-99 00:11:22
   ------------")))))
-
 
 (ert-deftest mastodon-tl--byline-boosted/favorited ()
   "Should format the boosted & favourited toot correctly."


### PR DESCRIPTION
`mastodon-notifications--get` will now create a `*mastodon-notifications*` buffer.

Four types of notifications have rendering functions
1. mention
2. follow
3. favourite
4. reblog (boost)

Mention, favourite, and boost are very similar to standard toots. Follows will have a tag line (which could be customizable) and will insert the image of the new follower before the end of the notification. 
## Mention
```
$content
 | $display_name (@$user_name) Mentioned $your_display_name(@$your_user_name)
  ------------
```

## Follow
```
Congratulations, you have a new follower!
;; dependent on the inclusion of  mastodon-media.el 
;; $user_image
 | $display_name (@$user_name) Following $your_display_name(@$your_user_name)
  ------------
```
## Favourite
```
$content
 | $display_name (@$user_name)  Favorited $your_display_name(@$your_user_name)
  ------------
```

## Booseted
```
$content
 | $display_name (@$user_name)  Boosted $your_display_name(@$your_user_name)
  ------------
```

The functionality will be in the `mastodon-notifications` module and will depend explicitly on `mastodon-media`, `mastodon-http` and `mastodon-tl`

A lot of the utility overlaps with those `mastdodon-tl`. For the time being I am using the functionality in from the `mastodon-tl` package for navigation, however a more generalized version of  updating functions like `mastodon-tl--more` will be required going forward. 

## Example from Emacs
![notifications buffer](https://cloud.githubusercontent.com/assets/6475397/25355983/9bb42afe-2906-11e7-980c-86626e6c5475.PNG)


