### PR TITLE
en #74 added autofill for tag timeline

### DIFF
--- a/lisp/mastodon-tl.el
+++ b/lisp/mastodon-tl.el
@@ -54,7 +54,10 @@
 (defun mastodon-tl--get-tag-timeline ()
   "Prompts for tag and opens its timeline."
   (interactive)
-  (let ((tag (read-string "Tag: ")))
+  (let* ((word (word-at-point))
+	 (input (read-string (format "Tag(%s): " word)))
+	 (tag (if (equal input "") word input)))
+    (print tag)
     (mastodon-tl--get (concat "tag/" tag))))
 
 (defun mastodon-tl--goto-toot-pos (find-pos refresh &optional pos)

--- a/lisp/mastodon-tl.el
+++ b/lisp/mastodon-tl.el
@@ -54,7 +54,7 @@
 (defun mastodon-tl--get-tag-timeline ()
   "Prompts for tag and opens its timeline."
   (interactive)
-  (let* ((word (word-at-point))
+  (let* ((word (or (word-at-point) ""))
 	 (input (read-string (format "Tag(%s): " word)))
 	 (tag (if (equal input "") word input)))
     (print tag)


### PR DESCRIPTION
Pressing `T` when in `mastodon-mode` will now include the word under Point as the default option.