### PR TITLE
Now display multiple attachments #110

### DIFF
--- a/lisp/mastodon-tl.el
+++ b/lisp/mastodon-tl.el
@@ -178,20 +178,15 @@ also render the html"
       "")))
 
 (defun mastodon-tl--media (toot)
-  "Retreive a media attachment link for TOOT if one exists."
+  "Retrieve a media attachment link for TOOT if one exists."
   (let ((media (mastodon-tl--field 'media_attachments toot)))
-    (if (> (length media) 0 )
-        ;; Extract the preview_url, other options here
-        ;; are url and remote_url
         (mapconcat
-         (lambda (image)
+         (lambda (media-preview)
            (concat "Media_Link:: "
                    (mastodon-tl--set-face
-                    (cdr (assoc 'preview_url image))
+                    (cdr (assoc 'preview_url media-preview))
                     'mouse-face 'nil)))
-         media "\n")
-      ;; Otherwise return an empty string
-      "")))
+         media "\n")))
 
 (defun mastodon-tl--content (toot)
   "Retrieve text content from TOOT."

--- a/lisp/mastodon-tl.el
+++ b/lisp/mastodon-tl.el
@@ -57,8 +57,8 @@
   "Prompts for tag and opens its timeline."
   (interactive)
   (let* ((word (or (word-at-point) ""))
-	 (input (read-string (format "Tag(%s): " word)))
-	 (tag (if (equal input "") word input)))
+         (input (read-string (format "Tag(%s): " word)))
+         (tag (if (equal input "") word input)))
     (print tag)
     (mastodon-tl--get (concat "tag/" tag))))
 
@@ -177,16 +177,19 @@ also render the html"
                                   "\n ---------------" (concat string cw))
       "")))
 
-
 (defun mastodon-tl--media (toot)
-  "Retreive a media attachment link if one exists."
+  "Retreive a media attachment link for TOOT if one exists."
   (let ((media (mastodon-tl--field 'media_attachments toot)))
     (if (> (length media) 0 )
         ;; Extract the preview_url, other options here
         ;; are url and remote_url
-        (let ((link (cdr(assoc 'preview_url (elt media 0)))))
-          (concat "Media_Link:: "
-                  (mastodon-tl--set-face link 'mouse-face 'nil)))
+        (mapconcat
+         (lambda (image)
+           (concat "Media_Link:: "
+                   (mastodon-tl--set-face
+                    (cdr (assoc 'preview_url image))
+                    'mouse-face 'nil)))
+         media "\n")
       ;; Otherwise return an empty string
       "")))
 


### PR DESCRIPTION
Adds as many `Media_link::` lines to a toot as their are media_attachments.
![snap-of-snap](https://cloud.githubusercontent.com/assets/6475397/25588699/691f8a36-2e77-11e7-980d-1b1924524e62.PNG)
