### PR TITLE
Added tooling for downloading individual toots

### DIFF
--- a/lisp/mastodon-inspect.el
+++ b/lisp/mastodon-inspect.el
@@ -55,5 +55,29 @@
            "*")
   (mastodon-tl--property 'toot-json)))
 
+(defun mastodon-inspect--download-single-toot (toot-id)
+  "Download the toot/status represented by TOOT-ID."
+  (mastodon-http--get-json
+   (mastodon-http--api (concat "statuses/" toot-id))))
+
+(defun mastodon-inspect--view-single-toot (toot-id)
+  "View the toot/status represented by TOOT-ID."
+  (interactive "s Toot ID: ")
+  (let ((buffer (get-buffer-create(concat "*mastodon-status-" toot-id "*"))))
+    (with-current-buffer buffer
+      (let ((toot (mastodon-inspect--download-single-toot toot-id )))
+        (mastodon-tl--toot toot)
+            (replace-regexp "\n\n\n | " "\n | " nil (point-min) (point-max))
+            (mastodon-media--inline-images)))
+    (switch-to-buffer-other-window buffer)
+    (mastodon-mode)))
+
+(defun mastodon-inspect--view-single-toot-source (toot-id)
+  "View the ess source of a toot/status represented by TOOT-ID."
+  (interactive "s Toot ID: ")
+  (mastodon-inspect--dump-json-in-buffer
+   (concat "*mastodon-status-raw-" toot-id "*")
+   (mastodon-inspect--download-single-toot toot-id)))
+
 (provide 'mastodon-inspect)
 ;;; mastodon-inspect.el ends here


### PR DESCRIPTION
Added three functions to the mastodon-inspect.el module.

1. `mastodon-inspect--download-single-toot` can be used to download a single toot and return its json parsed into elisp.

2. `mastodon-inspect--view-single-toot` renders the toot and displays it in a new buffer.

3. `mastodon-inspect--view-single-toot-source` displays the structure of the toot in a new buffer.