### PR TITLE
Closing #102 Fixing width

### DIFF
--- a/lisp/mastodon-tl.el
+++ b/lisp/mastodon-tl.el
@@ -160,7 +160,9 @@ also render the html"
    (with-temp-buffer
      (insert (decode-coding-string string 'utf-8))
      (when render
-       (shr-render-region (point-min) (point-max)))
+       (progn
+         (customize-set-value 'shr-use-fonts nil)
+         (shr-render-region (point-min) (point-max))))
      (buffer-string))
    'face face))
 
@@ -195,6 +197,7 @@ also render the html"
   (let ((content (mastodon-tl--field 'content toot)))
     (propertize (with-temp-buffer
                   (insert (decode-coding-string content 'utf-8))
+                  (customize-set-value 'shr-use-fonts nil)
                   (shr-render-region (point-min) (point-max))
                   (buffer-string))
                 'face 'default)))

--- a/lisp/mastodon-tl.el
+++ b/lisp/mastodon-tl.el
@@ -193,11 +193,11 @@ also render the html"
 
 (defun mastodon-tl--content (toot)
   "Retrieve text content from TOOT."
-  (let ((content (mastodon-tl--field 'content toot)))
+  (let ((content (mastodon-tl--field 'content toot))
+        (shr-use-fonts nil))
     (propertize (with-temp-buffer
                   (insert (decode-coding-string content 'utf-8))
-                  (let ((shr-use-fonts nil))
-                    (shr-render-region (point-min) (point-max)))
+                  (shr-render-region (point-min) (point-max))
                   (buffer-string))
                 'face 'default)))
 

--- a/lisp/mastodon-tl.el
+++ b/lisp/mastodon-tl.el
@@ -57,8 +57,8 @@
   "Prompts for tag and opens its timeline."
   (interactive)
   (let* ((word (or (word-at-point) ""))
-	 (input (read-string (format "Tag(%s): " word)))
-	 (tag (if (equal input "") word input)))
+         (input (read-string (format "Tag(%s): " word)))
+         (tag (if (equal input "") word input)))
     (print tag)
     (mastodon-tl--get (concat "tag/" tag))))
 
@@ -160,8 +160,7 @@ also render the html"
    (with-temp-buffer
      (insert (decode-coding-string string 'utf-8))
      (when render
-       (progn
-         (customize-set-value 'shr-use-fonts nil)
+       (let ((shr-use-fonts nil))
          (shr-render-region (point-min) (point-max))))
      (buffer-string))
    'face face))
@@ -197,8 +196,8 @@ also render the html"
   (let ((content (mastodon-tl--field 'content toot)))
     (propertize (with-temp-buffer
                   (insert (decode-coding-string content 'utf-8))
-                  (customize-set-value 'shr-use-fonts nil)
-                  (shr-render-region (point-min) (point-max))
+                  (let ((shr-use-fonts nil))
+                    (shr-render-region (point-min) (point-max)))
                   (buffer-string))
                 'face 'default)))
 


### PR DESCRIPTION
# Background
`shr-render-region` by default outputs proportional font and creates a new line whenever the text reaches the buffer width. By using `customize-set-value` and setting `shr-use-fonts` to `nil` we have it output the width of the current buffer using `'default` monospaced text. Alternatively we can provide the max width used by setting the customize able value `shr-width` to our preferred width.

# Implementation
In `mastodon-tl.el` before any call to `shr-render-region` I have set the `shr-use-fonts` to nil

As a stop gap measure you can set the `shr-use-fonts` to nil globaly using the `customize-set-variables` function

## Before
![screenshot 2017-05-02 22 56 44](https://cloud.githubusercontent.com/assets/6475397/25646869/abb1ddfe-2f8a-11e7-8a2e-e91555ad1c5d.png)

## After
![screenshot 2017-05-02 22 54 35](https://cloud.githubusercontent.com/assets/6475397/25646876/b7348a96-2f8a-11e7-8d6d-1016dccc5a88.png)

