### PR TITLE
Just some elisp cleanups

### DIFF
--- a/lisp/mastodon-auth.el
+++ b/lisp/mastodon-auth.el
@@ -67,10 +67,9 @@
 
 Generate token and set `mastodon-auth--token' if nil."
   (or mastodon-auth--token
-      (progn
-        (let* ((json (mastodon-auth--get-token))
-               (token (plist-get json :access_token)))
-          (setq mastodon-auth--token token)))))
+      (let* ((json (mastodon-auth--get-token))
+             (token (plist-get json :access_token)))
+        (setq mastodon-auth--token token))))
 
 (provide 'mastodon-auth)
 ;;; mastodon-auth.el ends here

--- a/lisp/mastodon-http.el
+++ b/lisp/mastodon-http.el
@@ -48,16 +48,14 @@
 (defun mastodon-http--response-body (pattern)
   "Return substring matching PATTERN from `mastodon-http--response'."
   (let ((resp (mastodon-http--response)))
-    (progn
-      (string-match pattern resp)
-      (match-string 0 resp))))
+    (string-match pattern resp)
+    (match-string 0 resp)))
 
 (defun mastodon-http--status ()
   "Return HTTP Response Status Code from `mastodon-http--response'."
   (let* ((status-line (mastodon-http--response-body "^HTTP/1.*$")))
-    (progn
-      (string-match "[0-9][0-9][0-9]" status-line)
-      (match-string 0 status-line))))
+    (string-match "[0-9][0-9][0-9]" status-line)
+    (match-string 0 status-line)))
 
 (defun mastodon-http--triage (response success)
   "Determine if RESPONSE was successful. Call SUCCESS if successful.

--- a/lisp/mastodon-inspect.el
+++ b/lisp/mastodon-inspect.el
@@ -39,12 +39,12 @@
 (defun mastodon-inspect--dump-json-in-buffer (name json)
   "Buffer NAME is opened and JSON in printed into it."
   (switch-to-buffer-other-window name)
-  (progn (setf print-level nil
-            print-length nil)
-         (insert (pp json t))
-         (goto-char 1)
-         (emacs-lisp-mode)
-         (message "success")))
+  (setf print-level nil
+        print-length nil)
+  (insert (pp json t))
+  (goto-char 1)
+  (emacs-lisp-mode)
+  (message "success"))
 
 (defun mastodon-inspect--toot ()
   "Find next toot and dump its meta data into new buffer."

--- a/lisp/mastodon-media.el
+++ b/lisp/mastodon-media.el
@@ -57,8 +57,8 @@ Returns the cons of (`start' . `end') points of that line or nil no
 more media links were found."
   (let ((foundp (search-forward-regexp "Media_Link::" nil t)))
     (when foundp
-      (let ((start (progn (move-beginning-of-line '()) (point)))
-            (end (progn (move-end-of-line '()) (point))))
+      (let ((start (progn (move-beginning-of-line nil) (point)))
+            (end (progn (move-end-of-line nil) (point))))
         (cons start end)))))
 
 (defun mastodon-media--valid-link-p (link)

--- a/lisp/mastodon-media.el
+++ b/lisp/mastodon-media.el
@@ -65,8 +65,8 @@ more media links were found."
   "Checks to make sure that the missing string has
 
 not been returned."
-  (let((missing "/files/small/missing.png"))
-    (not(equal link missing))))
+  (let ((missing "/files/small/missing.png"))
+    (not (equal link missing))))
 
 (defun mastodon-media--line-to-link (line-points)
   "Returns the url of the media link given at the given point.

--- a/lisp/mastodon-tl.el
+++ b/lisp/mastodon-tl.el
@@ -251,9 +251,8 @@ Move forward (down) the timeline unless BACKWARD is non-nil."
 
 (defun mastodon-tl--oldest-id ()
   "Return toot-id from the bottom of the buffer."
-  (progn
-    (goto-char (point-max))
-    (mastodon-tl--property 'toot-id t)))
+  (goto-char (point-max))
+  (mastodon-tl--property 'toot-id t))
 
 (defun mastodon-tl--thread ()
   "Open thread buffer for toot under `point'."

--- a/lisp/mastodon-tl.el
+++ b/lisp/mastodon-tl.el
@@ -154,7 +154,7 @@ Return value from boosted content if available."
      'toot-json    toot)))
 
 (defun mastodon-tl--set-face (string face render)
-  "Set the face of a string. If `render' is not 'nil
+  "Set the face of a string. If `render' is not nil
 also render the html"
   (propertize
    (with-temp-buffer
@@ -172,7 +172,7 @@ also render the html"
          (message (concat "\n ---------------"
                           "\n Content Warning"
                           "\n ---------------\n"))
-         (cw (mastodon-tl--set-face message 'success 'nil)))
+         (cw (mastodon-tl--set-face message 'success nil)))
     (if (> (length string) 0)
         (replace-regexp-in-string "\n\n\n ---------------"
                                   "\n ---------------" (concat string cw))
@@ -186,7 +186,7 @@ also render the html"
            (concat "Media_Link:: "
                    (mastodon-tl--set-face
                     (cdr (assoc 'preview_url media-preview))
-                    'mouse-face 'nil)))
+                    'mouse-face nil)))
          media "\n")))
 
 (defun mastodon-tl--content (toot)

--- a/lisp/mastodon-toot.el
+++ b/lisp/mastodon-toot.el
@@ -121,11 +121,10 @@ Set `mastodon-toot--content-warning' to nil."
                  ("sensitive" . ,(when mastodon-toot--content-warning
                                    (symbol-name t)))
                  ("spoiler_text" . ,spoiler))))
-    (progn
-      (mastodon-toot--kill)
-      (let ((response (mastodon-http--post endpoint args nil)))
-        (mastodon-http--triage response
-                               (lambda () (message "Toot toot!")))))))
+    (mastodon-toot--kill)
+    (let ((response (mastodon-http--post endpoint args nil)))
+      (mastodon-http--triage response
+                             (lambda () (message "Toot toot!"))))))
 
 (defun mastodon-toot--reply ()
   "Reply to toot at `point'."
@@ -151,9 +150,8 @@ Set `mastodon-toot--content-warning' to nil."
          (bindings (remove nil (mapcar (lambda (i) (if (listp i) i))
                                        (cadr binds)))))
     (mapcar (lambda (b)
-	      (progn
-		      (setf (car b) (vector prefix (car b)))
-		      b))
+              (setf (car b) (vector prefix (car b)))
+              b)
 	    bindings)))
 
 (defun mastodon-toot--format-kbind-command (cmd)

--- a/lisp/mastodon-toot.el
+++ b/lisp/mastodon-toot.el
@@ -43,10 +43,10 @@
 
 Remove MARKER if RM is non-nil."
   (let ((inhibit-read-only t)
-        (bol (progn (move-beginning-of-line '()) (point)))
-        (eol (progn (move-end-of-line '()) (point))))
-    (when rm (replace-regexp (format "(%s) " marker) "" '() bol eol))
-    (move-beginning-of-line '())
+        (bol (progn (move-beginning-of-line nil) (point)))
+        (eol (progn (move-end-of-line nil) (point))))
+    (when rm (replace-regexp (format "(%s) " marker) "" nil bol eol))
+    (move-beginning-of-line nil)
     (mastodon-tl--goto-next-toot)
     (unless rm
       (insert (format "(%s) "

--- a/lisp/mastodon-toot.el
+++ b/lisp/mastodon-toot.el
@@ -147,9 +147,9 @@ Set `mastodon-toot--content-warning' to nil."
 (defun mastodon-toot--get-mode-kbinds ()
   "Get a list of the keybindings in the mastodon-toot-mode."
   (let* ((binds (copy-tree mastodon-toot-mode-map))
-	       (prefix (car (cadr binds)))
-	       (bindings (remove nil (mapcar (lambda (i) (if (listp i) i))
-					                               (cadr binds)))))
+         (prefix (car (cadr binds)))
+         (bindings (remove nil (mapcar (lambda (i) (if (listp i) i))
+                                       (cadr binds)))))
     (mapcar (lambda (b)
 	      (progn
 		      (setf (car b) (vector prefix (car b)))


### PR DESCRIPTION
 - Don't quote nil.
 - Use the more canonical "nil" instead of "'()" when we don't mean an empty list.
 - Fix some whitespace issues.
 - Clean up use of progn.