### PR TITLE
added option to bound the search for the next media link

### DIFF
--- a/lisp/mastodon-media.el
+++ b/lisp/mastodon-media.el
@@ -51,10 +51,12 @@
       (kill-buffer buffer))))
 
 (defun mastodon-media--select-next-media-line (&optional end)
-  "Find coordinates of a line that contains `Media_Links::'
+  "Find coordinates of a line that contains `Media_Links::'.
 
-Returns the cons of (`start' . `end') points of that line or nil no
-more media links were found."
+END is an optional parameter that can be used to set the maximum
+bound durring `search-forward-regexp'. Returns the cons of 
+(`start' . `end') points of that line or nil no more media links 
+were found."
   (let ((foundp (search-forward-regexp "Media_Link::" end t)))
     (when foundp
       (let ((start (progn (move-beginning-of-line '()) (point)))

--- a/lisp/mastodon-media.el
+++ b/lisp/mastodon-media.el
@@ -50,12 +50,12 @@
           (insert-image (create-image data nil t)))
       (kill-buffer buffer))))
 
-(defun mastodon-media--select-next-media-line ()
+(defun mastodon-media--select-next-media-line (&optional end)
   "Find coordinates of a line that contains `Media_Links::'
 
 Returns the cons of (`start' . `end') points of that line or nil no
 more media links were found."
-  (let ((foundp (search-forward-regexp "Media_Link::" nil t)))
+  (let ((foundp (search-forward-regexp "Media_Link::" end t)))
     (when foundp
       (let ((start (progn (move-beginning-of-line '()) (point)))
             (end (progn (move-end-of-line '()) (point))))


### PR DESCRIPTION
For async image loading I would like to limit the range of images to update. 

This PR allows you to pass an optional variable `end` to `mastodon-media--select-next-media-line` which bounds the range of `search-forward-regexp`