### PR TITLE
Fix two issues with image loading

### DIFF
--- a/lisp/mastodon-media.el
+++ b/lisp/mastodon-media.el
@@ -201,9 +201,10 @@ found."
   "Checks to make sure that the missing string has
 
 not been returned."
-  (let ((missing "/files/small/missing.png"))
-    (and link
-         (not (equal link missing)))))
+  (and link
+       (> (length link) 8)
+       (or (string= "http://" (substring link 0 7))
+           (string= "https://" (substring link 0 8)))))
 
 (defun mastodon-media--inline-images ()
   "Find all `Media_Links:' in the buffer replacing them with the referenced image."


### PR DESCRIPTION
1. the detection of "invalid urls" was a bit too specific; I had at least one case of a different avatar url that wasn't matched
2. error handling in the async `url-retrieve` — I had assumed I'd get an error in the callback but instead (at least on Emacs 24) the `url-retrieve` call can throw an error which throws things off; we now handle that properly.

