### PR TITLE
Use auth-source-search for fetching and saving password

### DIFF
--- a/test/mastodon-auth-tests.el
+++ b/test/mastodon-auth-tests.el
@@ -3,19 +3,22 @@
 (ert-deftest generate-token ()
   "Should make `mastdon-http--post' request to generate auth token."
   (with-mock
-    (let ((mastodon-instance-url "https://instance.url"))
-      (mock (mastodon-client) => '(:client_id "id" :client_secret "secret"))
-      (mock (read-string "Email: ") => "foo@bar.com")
-      (mock (read-passwd "Password: ") => "password")
-      (mock (mastodon-http--post "https://instance.url/oauth/token"
-                                 '(("client_id" . "id")
-                                   ("client_secret" . "secret")
-                                    ("grant_type" . "password")
-                                    ("username" . "foo@bar.com")
-                                    ("password" . "password")
-                                    ("scope" . "read write follow"))
-                                 nil))
-      (mastodon-auth--generate-token))))
+   (let ((mastodon-instance-url "https://instance.url"))
+     (mock (mastodon-client) => '(:client_id "id" :client_secret "secret"))
+     (mock (auth-source-search :create t
+                               :host "https://instance.url"
+                               :port 443
+                               :require '(:user :secret))
+           => '((:user "foo@bar.com" :secret (lambda () "password"))))
+     (mock (mastodon-http--post "https://instance.url/oauth/token"
+                                '(("client_id" . "id")
+                                  ("client_secret" . "secret")
+                                  ("grant_type" . "password")
+                                  ("username" . "foo@bar.com")
+                                  ("password" . "password")
+                                  ("scope" . "read write follow"))
+                                nil))
+     (mastodon-auth--generate-token))))
 
 (ert-deftest get-token ()
   "Should generate token and return JSON response."


### PR DESCRIPTION
This gives users the ability to save their password to either the gpg-encrypted ~/.authinfo.gpg or
~/.authinfo so that they don't have to provide username/password each time. It's a bit messy due to this function's caller needing a buffer; I'm open to rewriting this to have two functions, one that just builds the post params alist, which also provides a place for people to advise it away if they'd prefer to not use auth-source for some reason.