### PR TITLE
Check if an id is a number before attempting to convert it. Closes #150

### DIFF
--- a/lisp/mastodon-tl.el
+++ b/lisp/mastodon-tl.el
@@ -267,7 +267,9 @@ also render the html"
                                        "&"
                                      "?")
                                    "max_id="
-                                   (number-to-string id)))))
+                                   (if (numberp id )
+                                       (number-to-string id)
+                                     id)))))
     (mastodon-http--get-json url)))
 
 ;; TODO
@@ -280,7 +282,9 @@ also render the html"
                                       "&"
                                     "?")
                                   "since_id="
-                                  (number-to-string id)))))
+                                  (if (numberp id)
+                                      (number-to-string id)
+                                    id)))))
     (mastodon-http--get-json url)))
 
 (defun mastodon-tl--property (prop &optional backward)

--- a/test/mastodon-tl-tests.el
+++ b/test/mastodon-tl-tests.el
@@ -103,6 +103,26 @@
       (mock (mastodon-http--get-json "https://instance.url/api/v1/timelines/foo?max_id=12345"))
       (mastodon-tl--more-json "timelines/foo" 12345))))
 
+(ert-deftest more-json-id-string ()
+  "Should request toots older than max_id.
+
+`mastodon-tl--more-json' should accept and id that is either
+a string or a numeric."
+  (let ((mastodon-instance-url "https://instance.url"))
+    (with-mock
+      (mock (mastodon-http--get-json "https://instance.url/api/v1/timelines/foo?max_id=12345"))
+      (mastodon-tl--more-json "timelines/foo" "12345"))))
+
+(ert-deftest update-json-id-string ()
+  "Should request toots more recent than since_id.
+
+`mastodon-tl--updated-json' should accept and id that is either
+a string or a numeric."  
+  (let ((mastodon-instance-url "https://instance.url"))
+    (with-mock
+      (mock (mastodon-http--get-json "https://instance.url/api/v1/timelines/foo?since_id=12345"))
+      (mastodon-tl--updated-json "timelines/foo" "12345"))))
+
 (ert-deftest mastodon-tl--byline-regular ()
   "Should format the regular toot correctly."
   (let ((mastodon-tl--show-avatars-p nil)


### PR DESCRIPTION
## Description
Checks to see if the id is a numeric before attempting to convert it to a string. 
