### PR TITLE
explicit media toggle and small bug fixes

### DIFF
--- a/lisp/mastodon-http.el
+++ b/lisp/mastodon-http.el
@@ -107,6 +107,7 @@ Pass response buffer to CALLBACK function."
                   (decode-coding-string
                    (buffer-substring-no-properties (point) (point-max))
                    'utf-8)))
+             (kill-buffer)
              (json-read-from-string json-string)))))
     json-vector))
 

--- a/lisp/mastodon-inspect.el
+++ b/lisp/mastodon-inspect.el
@@ -55,7 +55,7 @@
   (interactive)
   (mastodon-inspect--dump-json-in-buffer
    (concat "*mastodon-inspect-toot-"
-           (int-to-string (mastodon-tl--property 'toot-id))
+           (mastodon-tl--as-string (mastodon-tl--property 'toot-id))
            "*")
   (mastodon-tl--property 'toot-json)))
 

--- a/lisp/mastodon-toot.el
+++ b/lisp/mastodon-toot.el
@@ -70,7 +70,7 @@ Remove MARKER if RM is non-nil."
   "Take ACTION on toot at point, then execute CALLBACK."
   (let* ((id (mastodon-tl--property 'toot-id))
          (url (mastodon-http--api (concat "statuses/"
-                                         (number-to-string id)
+                                         (mastodon-tl--as-string id)
                                          "/"
                                          action))))
     (let ((response (mastodon-http--post url nil nil)))
@@ -79,7 +79,8 @@ Remove MARKER if RM is non-nil."
 (defun mastodon-toot--toggle-boost ()
   "Boost/unboost toot at `point'."
   (interactive)
-  (let* ((id (mastodon-tl--property 'toot-id))
+  (let* ((id (mastodon-tl--as-string
+              (mastodon-tl--property 'toot-id)))
          (boosted (get-text-property (point) 'boosted-p))
          (action (if boosted "unreblog" "reblog"))
          (msg (if boosted "unboosted" "boosted"))
@@ -87,19 +88,20 @@ Remove MARKER if RM is non-nil."
     (mastodon-toot--action action
                            (lambda ()
                              (mastodon-toot--action-success "B" remove)
-                             (message (format "%s #%d" msg id))))))
+                             (message (format "%s #%s" msg id))))))
 
 (defun mastodon-toot--toggle-favourite ()
   "Favourite/unfavourite toot at `point'."
   (interactive)
-  (let* ((id (mastodon-tl--property 'toot-id))
+  (let* ((id (mastodon-tl--as-string
+              (mastodon-tl--property 'toot-id)))
          (faved (get-text-property (point) 'favourited-p))
          (action (if faved "unfavourite" "favourite"))
          (remove (when faved t)))
     (mastodon-toot--action action
                            (lambda ()
                              (mastodon-toot--action-success "F" remove)
-                             (message (format "%sd #%d" action id))))))
+                             (message (format "%s #%s" action id))))))
 
 (defun mastodon-toot--kill ()
   "Kill `mastodon-toot-mode' buffer and window.
@@ -144,7 +146,7 @@ Set `mastodon-toot--content-warning' to nil."
   "Reply to toot at `point'."
   (interactive)
   (let* ((toot (mastodon-tl--property 'toot-json))
-         (id (number-to-string (mastodon-tl--field 'id toot)))
+         (id (mastodon-tl--as-string (mastodon-tl--field 'id toot)))
          (account (mastodon-tl--field 'account toot))
          (user (cdr (assoc 'username account))))
     (mastodon-toot user id)))

--- a/test/mastodon-tl-tests.el
+++ b/test/mastodon-tl-tests.el
@@ -97,6 +97,28 @@
   (let ((input "foobar</p>"))
     (should (string= (mastodon-tl--remove-html input) "foobar\n\n"))))
 
+(ert-deftest toot-id-boosted ()
+  "If a toot is boostedm, return the reblog id."
+  (should (string= (mastodon-tl--as-string
+                    (mastodon-tl--toot-id mastodon-tl-test-base-boosted-toot))
+                   "4543919")))
+
+(ert-deftest toot-id ()
+  "If a toot is boostedm, return the reblog id."
+  (should (string= (mastodon-tl--as-string
+                    (mastodon-tl--toot-id mastodon-tl-test-base-toot))
+                   "61208")))
+
+(ert-deftest as-string-1 ()
+  "Should accept a string or number and return a string."
+  (let ((id "1000"))
+      (should (string= (mastodon-tl--as-string id) id))))
+
+(ert-deftest as-string-2 ()
+  "Should accept a string or number and return a string."
+  (let ((id 1000))
+      (should (string= (mastodon-tl--as-string id) (number-to-string id)))))
+
 (ert-deftest more-json ()
   "Should request toots older than max_id."
   (let ((mastodon-instance-url "https://instance.url"))


### PR DESCRIPTION
## Summary
This PR closes #152  and extends the fix for #150 to all places where ids were being converted from numbers to strings. It also adds some small fixes to the behaviour of threads and fixes boosting and favouriting (unfavouriting and unboosting still don't work).

## Changes
1. We now kill the http get request buffer once JSON has been extracted. 
2. `mastodon-tl--as-string` was implemented and replaced any occurrence of `number-to-string` or `int-to-string`
3. Added variable `mastodon-tl--display-media-p`. By default it is `'t` but can be made a local buffer variable and set to `nil`. When `nil` rather than displaying the media it just provides a link `Media::<link>`
4. Fixed checking for faves and boosts, they should now render properly. The return from `json-read-from-string` for `nil` is `:json-false` which evaluates to `'t` in elisp.
5. Fixed the `format` string that gets printed when faving and boosting
6. Fixed `mastodon-tl--thread` updating and requesting and changed its behaviour such that it tries to open the original toot thread rather than the boosted thread. 
7. Added tests for both the new `mastodon-tl--as-string` function and the `mastodon-tl--toot-id` utility.