### PR TITLE
Fixes buffer switching issue and closes issue #158

### DIFF
--- a/lisp/mastodon-media.el
+++ b/lisp/mastodon-media.el
@@ -144,21 +144,21 @@ REGION-LENGTH is the length of the region that should be replaced with the image
                  (image (when data
                           (apply #'create-image data (when image-options 'imagemagick)
                                  t image-options))))
-            (switch-to-buffer (marker-buffer marker))
-            ;; Save narrowing in our buffer
-            (let ((inhibit-read-only t))
-              (save-restriction
-                (widen)
-                (put-text-property marker (+ marker region-length) 'media-state 'loaded)
-                (when image
-                  ;; We only set the image to display if we could load
-                  ;; it; we already have set a default image when we
-                  ;; added the tag.
-                  (put-text-property marker (+ marker region-length)
-                                     'display image))
-                ;; We are done with the marker; release it:
-                (set-marker marker nil)))
-            (kill-buffer url-buffer))))))
+            (with-current-buffer (marker-buffer marker)
+              ;; Save narrowing in our buffer
+              (let ((inhibit-read-only t))
+                (save-restriction
+                  (widen)
+                  (put-text-property marker (+ marker region-length) 'media-state 'loaded)
+                  (when image
+                    ;; We only set the image to display if we could load
+                    ;; it; we already have set a default image when we
+                    ;; added the tag.
+                    (put-text-property marker (+ marker region-length)
+                                       'display image))
+                  ;; We are done with the marker; release it:
+                  (set-marker marker nil)))
+              (kill-buffer url-buffer)))))))
 
 (defun mastodon-media--load-image-from-url (url media-type start region-length)
   "Takes a URL and MEDIA-TYPE and load the image asynchronously.

--- a/lisp/mastodon-tl.el
+++ b/lisp/mastodon-tl.el
@@ -297,7 +297,7 @@ also render the html"
                                  preview-url)
                               (concat "Media::" preview-url "\n"))))
                         media-attachements "")))
-    (if (not (and (not mastodon-tl--display-media-p)
+    (if (not (and mastodon-tl--display-media-p
                   (equal media-string "")))
         (concat "\n" media-string) "")))
 


### PR DESCRIPTION
-Small logic fix in mastodon-tl--media to remove redundant newline
-Replaced switch-to-buffer with with-current-buffer in mastodon-media--process-image-response

Squashed with merge to develop