### PR TITLE
Allow user to navigate interesting things in a buffer via tabbing.

### DIFF
--- a/lisp/mastodon.el
+++ b/lisp/mastodon.el
@@ -38,6 +38,8 @@
 (autoload 'mastodon-tl--get-tag-timeline "mastodon-tl")
 (autoload 'mastodon-tl--goto-next-toot "mastodon-tl")
 (autoload 'mastodon-tl--goto-prev-toot "mastodon-tl")
+(autoload 'mastodon-tl--next-tab-item "mastodon-tl")
+(autoload 'mastodon-tl--previous-tab-item "mastodon-tl")
 (autoload 'mastodon-tl--thread "mastodon-tl")
 (autoload 'mastodon-tl--update "mastodon-tl")
 (autoload 'mastodon-toot--compose-buffer "mastodon-toot")
@@ -131,7 +133,12 @@ If REPLY-TO-ID is non-nil, attach new toot to a conversation."
     (define-key map (kbd "r") #'mastodon-toot--reply)
     (define-key map (kbd "t") #'mastodon-tl--thread)
     (define-key map (kbd "T") #'mastodon-tl--get-tag-timeline)
-    (define-key map (kbd "u") #'mastodon-tl--update)))
+    (define-key map (kbd "u") #'mastodon-tl--update)
+    (define-key map [?\t] #'mastodon-tl--next-tab-item)
+    (define-key map [backtab] #'mastodon-tl--previous-tab-item)
+    (define-key map [?\S-\t] #'mastodon-tl--previous-tab-item)
+    (define-key map [?\M-\t] #'mastodon-tl--previous-tab-item)
+    ))
 
 (with-eval-after-load 'mastodon
   (when (require 'discover nil :noerror)


### PR DESCRIPTION
Use tab to go forward, M-tab and S-Tab to go back.

This has always been possible while on a hyperlink but now works everywhere.

Currently only hyperlinks are tab stops but in the future we will want to support other things and there are already TODO comments in the code to note where we may want to do this.

This is the start of work #166 (Tab to next important feature).