### PR TITLE
Generalizations for notifications

### DIFF
--- a/lisp/mastodon-tl.el
+++ b/lisp/mastodon-tl.el
@@ -332,7 +332,7 @@ TIME-STAMP is assumed to be in the past."
   "Generate byline for TOOT.
 
 AUTHOR-BYLINE is function for adding the author portion of 
-the byline that takes one variable. By default it is `mastodon-tl--byline-author'
+the byline that takes one variable.
 ACTION-BYLINE is a function for adding an action, such as boosting
 favouriting and following to the byline. It also takes a single function. By default
 it is `mastodon-tl--byline-boosted'"
@@ -541,26 +541,23 @@ message is a link which unhides/hides the main body."
      (mastodon-tl--render-text content toot)
      (mastodon-tl--media toot))))
 
-(defun mastodon-tl--insert (toot body author-byline action-byline)
-  "Display toot content and byline.
+(defun mastodon-tl--insert-status (toot body author-byline action-byline)
+  "Display the content and byline of a timeline element.
 
 BODY will form the section of the toot above the byline.
-AUTHOR-BYLINE and ACTION-BYLINE are optional functions that are passed to
-`mastodon-tl--byline'
 AUTHOR-BYLINE is an optional function for adding the author portion of 
 the byline that takes one variable. By default it is `mastodon-tl--byline-author'
 ACTION-BYLINE is also an optional function for adding an action, such as boosting
 favouriting and following to the byline. It also takes a single function. By default
 it is `mastodon-tl--byline-boosted'"
   (insert
-   ;; remove trailing whitespace
    body
    (mastodon-tl--byline toot author-byline action-byline)
    "\n\n"))
 
 (defun mastodon-tl--toot(toot)
   "Formats TOOT and insertes it into the buffer."
-  (mastodon-tl--insert
+  (mastodon-tl--insert-status
    toot
    (replace-regexp-in-string
     "[\t\n ]*\\'" ""
@@ -672,10 +669,10 @@ webapp"
          (toot (mastodon-tl--property 'toot-json))
          (context (mastodon-http--get-json url)))
     (when (member (cdr (assoc 'type toot)) '("reblog" "favourite"))
-      (setq toot (cdr(assoc 'status toot))))
+      (setq toot (cdr (assoc 'status toot))))
     (if (> (+ (length (cdr (assoc 'ancestors context)))
               (length (cdr (assoc 'descendants context))))
-           0)        
+           0)
         (with-output-to-temp-buffer buffer
           (switch-to-buffer buffer)
           (mastodon-mode)

--- a/test/mastodon-tl-tests.el
+++ b/test/mastodon-tl-tests.el
@@ -257,7 +257,9 @@ a string or a numeric."
       (mock (format-time-string mastodon-toot-timestamp-format '(22782 21551)) => "2999-99-99 00:11:22")
 
       (should (string= (substring-no-properties
-                        (mastodon-tl--byline mastodon-tl-test-base-toot))
+                        (mastodon-tl--byline mastodon-tl-test-base-toot
+                                             'mastodon-tl--byline-author
+                                             'mastodon-tl--byline-boosted))
                        "
  | Account 42 (@acct42@example.space) 2999-99-99 00:11:22
   ------------")))))
@@ -272,7 +274,9 @@ a string or a numeric."
       (mock (format-time-string mastodon-toot-timestamp-format '(22782 21551)) => "2999-99-99 00:11:22")
 
       (should (string= (substring-no-properties
-                        (mastodon-tl--byline mastodon-tl-test-base-toot))
+                        (mastodon-tl--byline mastodon-tl-test-base-toot
+                                             'mastodon-tl--byline-author
+                                             'mastodon-tl--byline-boosted))
                        "
  |   Account 42 (@acct42@example.space) 2999-99-99 00:11:22
   ------------")))))
@@ -286,7 +290,10 @@ a string or a numeric."
       (mock (date-to-time timestamp) => '(22782 21551))
       (mock (format-time-string mastodon-toot-timestamp-format '(22782 21551)) => "2999-99-99 00:11:22")
 
-      (should (string= (substring-no-properties (mastodon-tl--byline toot))
+      (should (string= (substring-no-properties
+                        (mastodon-tl--byline toot
+                                             'mastodon-tl--byline-author
+                                             'mastodon-tl--byline-boosted))
                       "
  | (B) Account 42 (@acct42@example.space) 2999-99-99 00:11:22
   ------------")))))
@@ -300,7 +307,10 @@ a string or a numeric."
       (mock (date-to-time timestamp) => '(22782 21551))
       (mock (format-time-string mastodon-toot-timestamp-format '(22782 21551)) => "2999-99-99 00:11:22")
 
-      (should (string= (substring-no-properties (mastodon-tl--byline toot))
+      (should (string= (substring-no-properties
+                        (mastodon-tl--byline toot
+                                             'mastodon-tl--byline-author
+                                             'mastodon-tl--byline-boosted))
                        "
  | (F) Account 42 (@acct42@example.space) 2999-99-99 00:11:22
   ------------")))))
@@ -315,7 +325,10 @@ a string or a numeric."
       (mock (date-to-time timestamp) => '(22782 21551))
       (mock (format-time-string mastodon-toot-timestamp-format '(22782 21551)) => "2999-99-99 00:11:22")
 
-      (should (string= (substring-no-properties (mastodon-tl--byline toot))
+      (should (string= (substring-no-properties
+                        (mastodon-tl--byline toot
+                                             'mastodon-tl--byline-author
+                                             'mastodon-tl--byline-boosted))
                        "
  | (B) (F) Account 42 (@acct42@example.space) 2999-99-99 00:11:22
   ------------")))))
@@ -335,7 +348,10 @@ a string or a numeric."
       (mock (date-to-time original-timestamp) => '(3 4))
       (mock (format-time-string mastodon-toot-timestamp-format '(3 4)) => "original time")
 
-      (should (string= (substring-no-properties (mastodon-tl--byline toot))
+      (should (string= (substring-no-properties
+                        (mastodon-tl--byline toot
+                                             'mastodon-tl--byline-author
+                                             'mastodon-tl--byline-boosted))
                       "
  | Account 42 (@acct42@example.space) Boosted Account 43 (@acct43@example.space) original time
   ------------")))))
@@ -356,8 +372,10 @@ a string or a numeric."
       (mock (date-to-time original-timestamp) => '(3 4))
       (mock (format-time-string mastodon-toot-timestamp-format '(3 4)) => "original time")
 
-      (should (string= (substring-no-properties (mastodon-tl--byline toot))
-                      "
+      (should (string= (substring-no-properties
+                        (mastodon-tl--byline toot
+                                             'mastodon-tl--byline-author
+                                             'mastodon-tl--byline-boosted))"
  |   Account 42 (@acct42@example.space) Boosted   Account 43 (@acct43@example.space) original time
   ------------")))))
 
@@ -376,7 +394,10 @@ a string or a numeric."
       (mock (date-to-time original-timestamp) => '(3 4))
       (mock (format-time-string mastodon-toot-timestamp-format '(3 4)) => "original time")
 
-      (should (string= (substring-no-properties (mastodon-tl--byline toot))
+      (should (string= (substring-no-properties
+                        (mastodon-tl--byline toot
+                                             'mastodon-tl--byline-author
+                                             'mastodon-tl--byline-boosted))
                       "
  | (B) (F) Account 42 (@acct42@example.space) Boosted Account 43 (@acct43@example.space) original time
   ------------")))))
@@ -390,7 +411,9 @@ a string or a numeric."
       (mock (current-time) => '(22782 22000))
       (mock (format-time-string mastodon-toot-timestamp-format '(22782 21551)) => "2999-99-99 00:11:22")
 
-      (let* ((formatted-string (mastodon-tl--byline mastodon-tl-test-base-toot))
+      (let* ((formatted-string (mastodon-tl--byline mastodon-tl-test-base-toot
+                                                    'mastodon-tl--byline-author
+                                                    'mastodon-tl--byline-boosted))
              (timestamp-start (string-match "2999-99-99" formatted-string))
              (properties (text-properties-at timestamp-start formatted-string)))
         (should (equal '(22782 21551) (plist-get properties 'timestamp)))


### PR DESCRIPTION
Generalizations of `mastodon-tl--toot` and `mastodon-tl--byline` that allow them to be used to render notifications.

Three new arguments are added to `mastodon-tl--toot`
1. body: appears above the byline
2. author-byline, a functions that defines how the author should be rendered and that defaults to `mastodon-tl--byline-author`
2. action-byline, a functions that defines how the action should be rendered. Actions include boosting, following, mentioned etc. It defaults to `mastodon-tl--byline-boosted`

I also removed the redundant removal of newlines in `mastodon-tl--timeline`