### PR TITLE
Fix missing thread notifications

### DIFF
--- a/lisp/mastodon-auth.el
+++ b/lisp/mastodon-auth.el
@@ -43,6 +43,9 @@
 (defvar mastodon-auth--token-alist nil
   "Alist of User access tokens keyed by instance url.")
 
+(defvar mastodon-auth--acct-alist nil
+  "Alist of account accts (name@domain) keyed by instance url.")
+
 (defun mastodon-auth--generate-token ()
   "Make POST to generate auth token."
   (mastodon-http--post
@@ -78,6 +81,21 @@ Generate token and set if none known yet."
         (setq token (plist-get json :access_token))
         (push (cons mastodon-instance-url token) mastodon-auth--token-alist)))
     token))
+
+(defun mastodon-auth--get-account-name ()
+  "Request user credentials and return an account name."
+  (cdr (assoc
+        'acct
+        (mastodon-http--get-json
+         (mastodon-http--api
+          "accounts/verify_credentials")))))
+
+(defun mastodon-auth--user-acct ()
+  "Return a mastodon user acct name."
+  (or (cdr (assoc  mastodon-instance-url mastodon-auth--acct-alist))
+      (let ((acct (mastodon-auth--get-account-name)))
+        (push (cons mastodon-instance-url acct) mastodon-auth--acct-alist)
+        acct)))
 
 (provide 'mastodon-auth)
 ;;; mastodon-auth.el ends here

--- a/lisp/mastodon-http.el
+++ b/lisp/mastodon-http.el
@@ -83,7 +83,7 @@ Authorization header is included by default unless UNAUTHENTICED-P is non-nil."
         (url-request-extra-headers
 	 (append
 	  (unless unauthenticed-p
-	    `(("Authorization" . (concat "Bearer " (mastodon-auth--access-token)))))
+	    `(("Authorization" . ,(concat "Bearer " (mastodon-auth--access-token)))))
 	  headers)))
     (with-temp-buffer
       (url-retrieve-synchronously url))))

--- a/lisp/mastodon-tl.el
+++ b/lisp/mastodon-tl.el
@@ -600,9 +600,11 @@ webapp"
          (buffer (format "*mastodon-thread-%s*" id))
          (toot (mastodon-tl--property 'toot-json))
          (context (mastodon-http--get-json url)))
+    (when (member (cdr (assoc 'type toot)) '("reblog" "favourite"))
+      (setq toot (cdr(assoc 'status toot))))
     (if (> (+ (length (cdr (assoc 'ancestors context)))
               (length (cdr (assoc 'descendants context))))
-           0)
+           0)        
         (with-output-to-temp-buffer buffer
           (switch-to-buffer buffer)
           (mastodon-mode)

--- a/lisp/mastodon-tl.el
+++ b/lisp/mastodon-tl.el
@@ -600,18 +600,22 @@ webapp"
          (buffer (format "*mastodon-thread-%s*" id))
          (toot (mastodon-tl--property 'toot-json))
          (context (mastodon-http--get-json url)))
-    (with-output-to-temp-buffer buffer
-      (switch-to-buffer buffer)
-      (mastodon-mode)
-      (setq mastodon-tl--buffer-spec
-            `(buffer-name ,buffer
-                          endpoint ,(format "statuses/%s/context" id)
-                          update-function
-                          (lambda(toot) (message "END of thread."))))
-      (mastodon-tl--timeline (vconcat
-                              (cdr (assoc 'ancestors context))
-                              `(,toot)
-                              (cdr (assoc 'descendants context)))))))
+    (if (> (+ (length (cdr (assoc 'ancestors context)))
+              (length (cdr (assoc 'descendants context))))
+           0)
+        (with-output-to-temp-buffer buffer
+          (switch-to-buffer buffer)
+          (mastodon-mode)
+          (setq mastodon-tl--buffer-spec
+                `(buffer-name ,buffer
+                              endpoint ,(format "statuses/%s/context" id)
+                              update-function
+                              (lambda(toot) (message "END of thread."))))
+          (mastodon-tl--timeline (vconcat
+                                  (cdr (assoc 'ancestors context))
+                                  `(,toot)
+                                  (cdr (assoc 'descendants context)))))
+      (message "No Thread!"))))
 
 (defun mastodon-tl--more ()
   "Append older toots to timeline."

--- a/lisp/mastodon-tl.el
+++ b/lisp/mastodon-tl.el
@@ -135,6 +135,7 @@ This also skips tab items in invisible text, i.e. hidden spoiler text."
         (search-pos (point)))
     (while (and (setq next-range (mastodon-tl--find-next-or-previous-property-range
                                   'mastodon-tab-stop search-pos nil))
+
                 (get-text-property (car next-range) 'invisible)
                 (setq search-pos (1+ (cdr next-range))))
       ;; do nothing, all the action in in the while condition
@@ -397,7 +398,6 @@ TIME-STAMP is assumed to be in the past."
                            (list 'invisible
                                  (not (get-text-property (car spoiler-text-region)
                                                          'invisible)))))))
-
 (defun mastodon-tl--make-link (string link-type)
   "Return a propertized version of STRING that will act like link.
 
@@ -488,6 +488,7 @@ message is a link which unhides/hides the main body."
   (insert
    (concat
     ;; remove trailing whitespace
+
     (replace-regexp-in-string
      "[\t\n ]*\\'" ""
      (if (mastodon-tl--has-spoiler toot)

--- a/lisp/mastodon-toot.el
+++ b/lisp/mastodon-toot.el
@@ -48,7 +48,6 @@
       map)
   "Keymap for `mastodon-toot'.")
 
-
 (defun mastodon-toot--action-success (marker &optional rm)
   "Insert MARKER with 'success face in byline.
 
@@ -142,14 +141,40 @@ Set `mastodon-toot--content-warning' to nil."
       (mastodon-http--triage response
                              (lambda () (message "Toot toot!"))))))
 
+(defun mastodon-toot--process-local (acct)
+  "Adds domain to local ACCT and replaces the curent user name with \"\".
+
+Mastodon requires the full user@domain, even in the case of local accts. 
+eg. \"user\" -> \"user@local.social \" (when local.social is the domain of the 
+mastodon-instance-url).
+eg. \"yourusername\" -> \"\"
+eg. \"feduser@fed.social\" -> \"feduser@fed.social\" "
+  (cond ((string-match-p "@" acct) (concat "@" acct " ")) ; federated acct
+        ((string= (mastodon-auth--user-acct) acct) "") ; your acct
+        (t (concat "@" acct "@" ; local acct
+                   (cadr (split-string mastodon-instance-url "/" t)) " "))))
+
+(defun mastodon-toot--mentions (status)
+  "Extract mentions from STATUS and process them into a string."
+  (interactive)
+  (let ((mentions (cdr (assoc 'mentions status))))
+    (mapconcat (lambda(x) (mastodon-toot--process-local
+                           (cdr (assoc 'acct x))))
+               ;; reverse does not work on vectors in 24.5
+               (reverse (append mentions nil))
+               "")))
+
 (defun mastodon-toot--reply ()
   "Reply to toot at `point'."
   (interactive)
   (let* ((toot (mastodon-tl--property 'toot-json))
          (id (mastodon-tl--as-string (mastodon-tl--field 'id toot)))
          (account (mastodon-tl--field 'account toot))
-         (user (cdr (assoc 'username account))))
-    (mastodon-toot user id)))
+         (user (cdr (assoc 'acct account)))
+         (mentions (mastodon-toot--mentions toot)))
+    (mastodon-toot (when user (concat (mastodon-toot--process-local user)
+                                      mentions))
+                   id)))
 
 (defun mastodon-toot--toggle-warning ()
   "Toggle `mastodon-toot--content-warning'."
@@ -211,7 +236,8 @@ e.g. mastodon-toot--send -> Send."
   "If REPLY-TO-USER is provided, inject their handle into the message.
 If REPLY-TO-ID is provided, set the MASTODON-TOOT--REPLY-TO-ID var."
   (when reply-to-user
-    (insert (format "@%s " reply-to-user))
+    (insert (format "%s " reply-to-user))
+    (make-variable-buffer-local 'mastodon-toot--reply-to-id)
     (setq mastodon-toot--reply-to-id reply-to-id)))
 
 (defun mastodon-toot--compose-buffer (reply-to-user reply-to-id)

--- a/test/mastodon-toot-tests.el
+++ b/test/mastodon-toot-tests.el
@@ -1,5 +1,44 @@
 (require 'el-mock)
 
+(defconst mastodon-toot-multi-mention
+  '((mentions .
+              [((id . "1")
+                (username . "federated")
+                (url . "https://site.cafe/@federated")
+                (acct . "federated@federated.cafe"))
+               ((id . "1")
+                (username . "federated")
+                (url . "https://site.cafe/@federated")
+                (acct . "federated@federated.social"))
+               ((id . "1")
+                (username . "local")
+                (url . "")
+                (acct . "local"))])))
+
+(defconst mastodon-toot-no-mention
+  '((mentions . [])))
+
+(ert-deftest toot-multi-mentions ()
+  (let ((mastodon-auth--acct-alist '(("https://local.social". "null")))
+        (mastodon-instance-url "https://local.social"))    
+    (should (string=
+             (mastodon-toot--mentions mastodon-toot-multi-mention)
+             "@local@local.social @federated@federated.social @federated@federated.cafe "))))
+
+(ert-deftest toot-multi-mentions-with-name ()
+  (let ((mastodon-auth--acct-alist
+         '(("https://local.social". "local")))
+        (mastodon-instance-url "https://local.social"))
+    (should (string=
+             (mastodon-toot--mentions mastodon-toot-multi-mention)
+             "@federated@federated.social @federated@federated.cafe "))))
+
+(ert-deftest toot-no-mention ()
+  (let ((mastodon-auth--acct-alist
+         '(("https://local.social". "null")))
+        (mastodon-instance-url "https://local.social"))    
+    (should (string= (mastodon-toot--mentions mastodon-toot-no-mention) ""))))
+
 (ert-deftest cancel ()
   (with-mock
     (mock (kill-buffer-and-window))


### PR DESCRIPTION
`mastodon-tl--thread` throws errors when used with notifications. 

This PR adds some defense arround `mastodon-tl--timeline` as called from within `mastodon-tl--thread`