### PR TITLE
Clean up code to remove compilation warnings.

### DIFF
--- a/lisp/mastodon-auth.el
+++ b/lisp/mastodon-auth.el
@@ -32,6 +32,8 @@
 (require 'plstore)
 
 (autoload 'mastodon-client "mastodon-client")
+(autoload 'mastodon-http--api "mastodon-http")
+(autoload 'mastodon-http--get-json "mastodon-http")
 (autoload 'mastodon-http--post "mastodon-http")
 (defvar mastodon-instance-url)
 

--- a/lisp/mastodon-inspect.el
+++ b/lisp/mastodon-inspect.el
@@ -32,6 +32,7 @@
 (autoload 'mastodon-http--get-json "mastodon-http")
 (autoload 'mastodon-media--inline-images "mastodon-media")
 (autoload 'mastodon-mode "mastodon")
+(autoload 'mastodon-tl--as-string "mastodon-tl")
 (autoload 'mastodon-tl--property "mastodon-tl")
 (autoload 'mastodon-tl--toot "mastodon-tl")
 

--- a/lisp/mastodon-tl.el
+++ b/lisp/mastodon-tl.el
@@ -39,6 +39,7 @@
 (autoload 'mastodon-media--get-media-link-rendering "mastodon-media")
 (autoload 'mastodon-media--inline-images "mastodon-media")
 (autoload 'mastodon-mode "mastodon")
+(defvar mastodon-instance-url)
 (defvar mastodon-toot-timestamp-format)
 (defvar shr-use-fonts)  ;; need to declare it since Emacs24 didn't have this
 
@@ -392,7 +393,6 @@ links in the text."
          keymap
          (help-echo (get-text-property start 'help-echo))
          extra-properties
-         (parsed-url (url-generic-parse-url url))
          (toot-url (mastodon-tl--field 'url toot))
          (toot-url (when toot-url (url-generic-parse-url toot-url)))
          (toot-instance-url (if toot-url

--- a/lisp/mastodon-toot.el
+++ b/lisp/mastodon-toot.el
@@ -29,16 +29,22 @@
 
 ;;; Code:
 
-(defvar mastodon-toot--reply-to-id nil)
+(defvar mastodon-instance-url)
 (defvar mastodon-toot--content-warning nil)
 
+(autoload 'mastodon-auth--user-acct "mastodon-auth")
 (autoload 'mastodon-http--api "mastodon-http")
 (autoload 'mastodon-http--post "mastodon-http")
 (autoload 'mastodon-http--triage "mastodon-http")
+(autoload 'mastodon-tl--as-string "mastodon-tl")
 (autoload 'mastodon-tl--field "mastodon-tl")
 (autoload 'mastodon-tl--goto-next-toot "mastodon-tl")
 (autoload 'mastodon-tl--property "mastodon-tl")
 (autoload 'mastodon-toot "mastodon")
+
+(defvar mastodon-toot--reply-to-id nil
+  "Buffer-local variable to hold the id of the toot being replied to.")
+(make-variable-buffer-local 'mastodon-toot--reply-to-id)
 
 (defvar mastodon-toot-mode-map
   (let ((map (make-sparse-keymap)))
@@ -237,7 +243,6 @@ e.g. mastodon-toot--send -> Send."
 If REPLY-TO-ID is provided, set the MASTODON-TOOT--REPLY-TO-ID var."
   (when reply-to-user
     (insert (format "%s " reply-to-user))
-    (make-variable-buffer-local 'mastodon-toot--reply-to-id)
     (setq mastodon-toot--reply-to-id reply-to-id)))
 
 (defun mastodon-toot--compose-buffer (reply-to-user reply-to-id)


### PR DESCRIPTION
We used to be clean but have slipped recently.
Let's clean up the code so it's easier to see real code smell warnings in the compilation.