### PR TITLE
Support toggling content warning anywhere in the toot.

### DIFF
--- a/README.org
+++ b/README.org
@@ -77,6 +77,7 @@ Opens a =*mastodon-home*= buffer in the major mode so you can see toots. You wil
 | Key                      | Action                                                                            |
 |--------------------------+-----------------------------------------------------------------------------------|
 | =?=                      | Open context menu (if =discover= is available)                                    |
+| =c=                      | Toggle the visibility of sensitive text (if there is text with a content warning) |
 | =b=                      | Boost toot under =point=                                                          |
 | =f=                      | Favourite toot under =point=                                                      |
 | =F=                      | Open federated timeline                                                           |

--- a/lisp/mastodon.el
+++ b/lisp/mastodon.el
@@ -41,6 +41,7 @@
 (autoload 'mastodon-tl--next-tab-item "mastodon-tl")
 (autoload 'mastodon-tl--previous-tab-item "mastodon-tl")
 (autoload 'mastodon-tl--thread "mastodon-tl")
+(autoload 'mastodon-tl--toggle-spoiler-text-in-toot "mastodon-tl")
 (autoload 'mastodon-tl--update "mastodon-tl")
 (autoload 'mastodon-toot--compose-buffer "mastodon-toot")
 (autoload 'mastodon-toot--reply "mastodon-toot")
@@ -120,6 +121,7 @@ If REPLY-TO-ID is non-nil, attach new toot to a conversation."
   "Major mode for Mastodon, the federated microblogging network."
   :group 'mastodon
   (let ((map mastodon-mode-map))
+    (define-key map (kbd "c") #'mastodon-tl--toggle-spoiler-text-in-toot)
     (define-key map (kbd "b") #'mastodon-toot--toggle-boost)
     (define-key map (kbd "f") #'mastodon-toot--toggle-favourite)
     (define-key map (kbd "F") #'mastodon-tl--get-federated-timeline)

--- a/test/mastodon-tl-tests.el
+++ b/test/mastodon-tl-tests.el
@@ -817,6 +817,10 @@ constant."
         (mastodon-tl--spoiler normal-toot-with-spoiler)))
       (setq toot-end (point))
       (insert "\nsome more text.")
+      (add-text-properties
+       toot-start toot-end
+       (list 'toot-json normal-toot-with-spoiler
+	     'toot-id (cdr (assoc 'id normal-toot-with-spoiler))))
 
       (goto-char toot-start)
       (should (eq t (looking-at "This is the spoiler warning text")))
@@ -843,7 +847,22 @@ constant."
       (mastodon-tl--do-link-action-at-point (car link-region)) 
 
       ;; The body is invisible again:
-      (should (eq t (get-text-property body-position 'invisible))))))
+      (should (eq t (get-text-property body-position 'invisible)))
+
+      ;; Go back to the toot's beginning
+      (goto-char toot-start)
+      ;; Press 'c' and the body is visible again and point hasn't changed:
+      (mastodon-tl--toggle-spoiler-text-in-toot)
+      (should (eq nil (get-text-property body-position 'invisible)))
+      (should (eq toot-start (point)))
+      
+      ;; Go to the toot's end
+      (goto-char toot-end)
+      ;; Press 'c' and the body is invisible again and point hasn't changed:
+      (mastodon-tl--toggle-spoiler-text-in-toot)
+      (should (eq t (get-text-property body-position 'invisible)))
+      (should (eq toot-end (point)))
+      )))
 
 (ert-deftest mastodon-tl--hashtag ()
   "Should recognise hashtags in a toot and add the required properties to it."


### PR DESCRIPTION
This new functionality is bound to the 'c' key.

To help with this functionality this also changes the 'toot-json and 'toot-id properties.  These are now applied to the whole toot not just the toot's byline.