### PR TITLE
Optionally use auth-source-search for fetching and saving password.

### DIFF
--- a/README.org
+++ b/README.org
@@ -65,6 +65,10 @@ Set =mastodon-instance-url= in your =.emacs= or =customize=. Defaults to the [[h
     (setq mastodon-instance-url "https://my.instance.url")
 #+END_SRC
 
+There is an option to have your user credentials (email address and password) saved to disk so you don't have to re-enter them on every restart.
+The default is not to do this because if not properly configured it would save these unencrypted which is not a good default to have.
+Customize the variable =mastodon-auth-source-file= if you want to enable this feature.
+
 *** Timelines
 
 =M-x mastodon=

--- a/lisp/mastodon-auth.el
+++ b/lisp/mastodon-auth.el
@@ -30,6 +30,7 @@
 ;;; Code:
 
 (require 'plstore)
+(require 'auth-source)
 
 (autoload 'mastodon-client "mastodon-client")
 (autoload 'mastodon-http--api "mastodon-http")
@@ -50,16 +51,30 @@
 
 (defun mastodon-auth--generate-token ()
   "Make POST to generate auth token."
-  (mastodon-http--post
-   (concat mastodon-instance-url "/oauth/token")
-   `(("client_id" . ,(plist-get (mastodon-client) :client_id))
-     ("client_secret" . ,(plist-get (mastodon-client) :client_secret))
-     ("grant_type" . "password")
-     ("username" . ,(read-string "Email: "))
-     ("password" . ,(read-passwd "Password: "))
-     ("scope" . "read write follow"))
-   nil
-   :unauthenticated))
+  (let* ((auth-source-creation-prompts
+          '((user . "Enter email for %h: ")
+            (secret . "Password: ")))
+         (credentials-plist (nth 0 (auth-source-search
+                                    :create t
+                                    :host mastodon-instance-url
+                                    :port 443
+                                    :require '(:user :secret)))))
+    (prog1
+        (mastodon-http--post
+         (concat mastodon-instance-url "/oauth/token")
+         `(("client_id" . ,(plist-get (mastodon-client) :client_id))
+           ("client_secret" . ,(plist-get (mastodon-client) :client_secret))
+           ("grant_type" . "password")
+           ("username" . ,(plist-get credentials-plist :user))
+           ("password" . ,(let ((secret (plist-get credentials-plist :secret)))
+                            (if (functionp secret)
+                                (funcall secret)
+                              secret)))
+           ("scope" . "read write follow"))
+         nil
+	 :unauthenticated)
+      (when (functionp (plist-get credentials-plist :save-function))
+        (funcall (plist-get credentials-plist :save-function))))))
 
 (defun mastodon-auth--get-token ()
   "Make auth token request and return JSON response."

--- a/test/mastodon-auth-tests.el
+++ b/test/mastodon-auth-tests.el
@@ -3,20 +3,23 @@
 (ert-deftest generate-token ()
   "Should make `mastdon-http--post' request to generate auth token."
   (with-mock
-    (let ((mastodon-instance-url "https://instance.url"))
-      (mock (mastodon-client) => '(:client_id "id" :client_secret "secret"))
-      (mock (read-string "Email: ") => "foo@bar.com")
-      (mock (read-passwd "Password: ") => "password")
-      (mock (mastodon-http--post "https://instance.url/oauth/token"
-                                 '(("client_id" . "id")
-                                   ("client_secret" . "secret")
-                                    ("grant_type" . "password")
-                                    ("username" . "foo@bar.com")
-                                    ("password" . "password")
-                                    ("scope" . "read write follow"))
-                                 nil
-                                 :unauthenticated))
-      (mastodon-auth--generate-token))))
+   (let ((mastodon-instance-url "https://instance.url"))
+     (mock (mastodon-client) => '(:client_id "id" :client_secret "secret"))
+     (mock (auth-source-search :create t
+                               :host "https://instance.url"
+                               :port 443
+                               :require '(:user :secret))
+           => '((:user "foo@bar.com" :secret (lambda () "password"))))
+     (mock (mastodon-http--post "https://instance.url/oauth/token"
+                                '(("client_id" . "id")
+                                  ("client_secret" . "secret")
+                                  ("grant_type" . "password")
+                                  ("username" . "foo@bar.com")
+                                  ("password" . "password")
+                                  ("scope" . "read write follow"))
+                                nil
+				:unauthenticated))
+     (mastodon-auth--generate-token))))
 
 (ert-deftest get-token ()
   "Should generate token and return JSON response."


### PR DESCRIPTION
This gives users the ability to save their password to either the gpg-encrypted ~/.authinfo.gpg or
~/.authinfo so that they don't have to provide username/password each time

By default this feature is off since without any changes, things would default to saving credentials to unencrypted storage which is not a good user default.