### PR TITLE
Some small tweaks to our keymap handling.

### DIFF
--- a/README.org
+++ b/README.org
@@ -76,24 +76,32 @@ Opens a =*mastodon-home*= buffer in the major mode so you can see toots. You wil
 |--------------------------+-----------------------------------------------------------------------------------|
 | Key                      | Action                                                                            |
 |--------------------------+-----------------------------------------------------------------------------------|
+|                          | /In-buffer navigation/                                                            |
+| =<space>=                | Scroll up (i.e. move down to older items)                                         |
+| =<delete>=               | Scroll down (i.e. move up to newer items)                                         |
+| =<=                      | Move to beginning of buffer                                                       |
+| =>=                      | Move to end of buffer                                                             |
+| =j=                      | Go to next item (toot, notification)                                              |
+| =k=                      | Go to previous item (toot, notification)                                          |
+| =<tab>=                  | Go to the next interesting thing that has an action                               |
+| =<S-tab>=                | Go to the previous interesting thing that has an action                           |
+|                          | /In-buffer actions/                                                               |
 | =?=                      | Open context menu (if =discover= is available)                                    |
 | =c=                      | Toggle the visibility of sensitive text (if there is text with a content warning) |
 | =b=                      | Boost toot under =point=                                                          |
 | =f=                      | Favourite toot under =point=                                                      |
+| =r=                      | Reply to toot under =point=                                                       |
+| =<return>= / =<mouse-2>= | Perform action for the thing under point (or under mouse for =<mouse-2>=) if any  |
+| =n=                      | Compose a new toot                                                                |
+|                          | /Switching to other buffers and quitting/                                         |
+| =N=                      | Open buffer with notifications                                                    |
 | =F=                      | Open federated timeline                                                           |
 | =H=                      | Open home timeline                                                                |
-| =j=                      | Go to next toot                                                                   |
-| =k=                      | Go to previous toot                                                               |
 | =L=                      | Open local timeline                                                               |
-| =n=                      | Switch to =mastodon-toot= buffer                                                  |
-| =q=                      | Quit mastodon buffer. Leave window open.                                          |
-| =Q=                      | Quit mastodon buffer and kill window.                                             |
-| =r=                      | Reply to toot under =point=.                                                      |
-| =t=                      | Open thread buffer for toot under =point=.                                        |
+| =t=                      | Open thread buffer for toot under =point=                                         |
 | =T=                      | Prompt for tag and open its timeline                                              |
-| =<tab>=                  | Go to the next interesting thing that has an action.                              |
-| =<S-tab>=                | Go to the previous interesting thing that has an action.                          |
-| =<return>= / =<mouse-2>= | Perform action for the thing under point (or under mouse for =<mouse-2>=) if any. |
+| =q=                      | Quit mastodon buffer, leave window open                                           |
+| =Q=                      | Quit mastodon buffer and kill window                                              |
 |--------------------------+-----------------------------------------------------------------------------------|
 
 **** Legend

--- a/lisp/mastodon-tl.el
+++ b/lisp/mastodon-tl.el
@@ -88,10 +88,6 @@ width fonts when rendering HTML text"))
     (define-key map [return] 'mastodon-tl--do-link-action-at-point)
     (define-key map [mouse-2] 'mastodon-tl--do-link-action)
     (define-key map [follow-link] 'mouse-face)
-    (define-key map [tab] 'mastodon-tl--next-tab-item)
-    (define-key map [M-tab] 'mastodon-tl--previous-tab-item)
-    (define-key map [S-tab] 'mastodon-tl--previous-tab-item)
-    (define-key map [backtab] 'mastodon-tl--previous-tab-item)
     (keymap-canonicalize map))
   "The keymap set for things in the buffer that act like links (except for shr.el generate links).
 

--- a/lisp/mastodon.el
+++ b/lisp/mastodon.el
@@ -32,6 +32,7 @@
 ;;; Code:
 (declare-function discover-add-context-menu "discover")
 (declare-function emojify-mode "emojify")
+(autoload 'special-mode "simple")
 (autoload 'mastodon-tl--get-federated-timeline "mastodon-tl")
 (autoload 'mastodon-tl--get-home-timeline "mastodon-tl")
 (autoload 'mastodon-tl--get-local-timeline "mastodon-tl")
@@ -68,7 +69,33 @@ Use. e.g. \"%c\" for your locale's date and time format."
   :type 'string)
 
 (defvar mastodon-mode-map
-  (make-sparse-keymap)
+  (let ((map (make-sparse-keymap)))
+    ;; Navigation
+    (define-key map (kbd "j") #'mastodon-tl--goto-next-toot)
+    (define-key map (kbd "k") #'mastodon-tl--goto-prev-toot)
+    (define-key map [?\t] #'mastodon-tl--next-tab-item)
+    (define-key map [backtab] #'mastodon-tl--previous-tab-item)
+    (define-key map [?\S-\t] #'mastodon-tl--previous-tab-item)
+    (define-key map [?\M-\t] #'mastodon-tl--previous-tab-item)
+    ;; Navigating to other buffers:
+    (define-key map (kbd "N") #'mastodon-notifications--get)
+    (define-key map (kbd "F") #'mastodon-tl--get-federated-timeline)
+    (define-key map (kbd "H") #'mastodon-tl--get-home-timeline)
+    (define-key map (kbd "L") #'mastodon-tl--get-local-timeline)
+    (define-key map (kbd "t") #'mastodon-tl--thread)
+    (define-key map (kbd "T") #'mastodon-tl--get-tag-timeline)
+    (define-key map (kbd "q") #'kill-this-buffer)
+    (define-key map (kbd "Q") #'kill-buffer-and-window)
+    ;; Actions
+    (define-key map (kbd "c") #'mastodon-tl--toggle-spoiler-text-in-toot)
+    (define-key map (kbd "g") #'undefined) ;; override special mode binding
+    (define-key map (kbd "n") #'mastodon-toot)
+    (define-key map (kbd "r") #'mastodon-toot--reply)
+    (define-key map (kbd "u") #'mastodon-tl--update)
+    (define-key map (kbd "b") #'mastodon-toot--toggle-boost)
+    (define-key map (kbd "f") #'mastodon-toot--toggle-favourite)
+    ;; Finally, return the map:
+    map)
   "Keymap for `mastodon-mode'.")
 
 (defcustom mastodon-mode-hook nil
@@ -117,31 +144,10 @@ If REPLY-TO-ID is non-nil, attach new toot to a conversation."
                                 (when (require 'emojify nil :noerror)
                                   (emojify-mode t))))
 
-(define-derived-mode mastodon-mode nil "Mastodon"
+(define-derived-mode mastodon-mode special-mode "Mastodon"
   "Major mode for Mastodon, the federated microblogging network."
   :group 'mastodon
-  (let ((map mastodon-mode-map))
-    (define-key map (kbd "c") #'mastodon-tl--toggle-spoiler-text-in-toot)
-    (define-key map (kbd "b") #'mastodon-toot--toggle-boost)
-    (define-key map (kbd "f") #'mastodon-toot--toggle-favourite)
-    (define-key map (kbd "F") #'mastodon-tl--get-federated-timeline)
-    (define-key map (kbd "H") #'mastodon-tl--get-home-timeline)
-    (define-key map (kbd "j") #'mastodon-tl--goto-next-toot)
-    (define-key map (kbd "k") #'mastodon-tl--goto-prev-toot)
-    (define-key map (kbd "L") #'mastodon-tl--get-local-timeline)
-    (define-key map (kbd "n") #'mastodon-toot)
-    (define-key map (kbd "q") #'kill-this-buffer)
-    (define-key map (kbd "Q") #'kill-buffer-and-window)
-    (define-key map (kbd "r") #'mastodon-toot--reply)
-    (define-key map (kbd "t") #'mastodon-tl--thread)
-    (define-key map (kbd "T") #'mastodon-tl--get-tag-timeline)
-    (define-key map (kbd "u") #'mastodon-tl--update)
-    (define-key map [?\t] #'mastodon-tl--next-tab-item)
-    (define-key map [backtab] #'mastodon-tl--previous-tab-item)
-    (define-key map [?\S-\t] #'mastodon-tl--previous-tab-item)
-    (define-key map [?\M-\t] #'mastodon-tl--previous-tab-item)
-    (define-key map (kbd "N") #'mastodon-notifications--get)    
-    ))
+  (read-only-mode 1))
 
 (with-eval-after-load 'mastodon
   (when (require 'discover nil :noerror)


### PR DESCRIPTION
- Use special mode which sets up a sensible base keymap.
- Define the keymap just once so that users can tweak it as they wish
  without us messing with that on each invocation of mastodon-mode.