### PR TITLE
Toggle read-only when inserting thread contents.

### DIFF
--- a/lisp/mastodon-tl.el
+++ b/lisp/mastodon-tl.el
@@ -701,10 +701,11 @@ webapp"
                               endpoint ,(format "statuses/%s/context" id)
                               update-function
                               (lambda(toot) (message "END of thread."))))
-          (mastodon-tl--timeline (vconcat
-                                  (cdr (assoc 'ancestors context))
-                                  `(,toot)
-                                  (cdr (assoc 'descendants context)))))
+          (let ((inhibit-read-only t))
+            (mastodon-tl--timeline (vconcat
+                                    (cdr (assoc 'ancestors context))
+                                    `(,toot)
+                                    (cdr (assoc 'descendants context))))))
       (message "No Thread!"))))
 
 (defun mastodon-tl--more ()


### PR DESCRIPTION
Inhibit read only when inserting the contents of a thread.

Fixes small bug introduced in #183.