### PR TITLE
Give `mastodon-media--inline-images` a saner interface.

### DIFF
--- a/lisp/mastodon-inspect.el
+++ b/lisp/mastodon-inspect.el
@@ -75,7 +75,7 @@
         (goto-char (point-min))
         (while (search-forward "\n\n\n | " nil t)
           (replace-match "\n | "))
-        (mastodon-media--inline-images)))
+        (mastodon-media--inline-images (point-min) (point-max))))
     (switch-to-buffer-other-window buffer)
     (mastodon-mode)))
 

--- a/lisp/mastodon-notifications.el
+++ b/lisp/mastodon-notifications.el
@@ -111,15 +111,17 @@
 (defun mastodon-notifications--by-type (note)
   "Filters NOTE for those listed in `mastodon-notifications--types-alist'."
   (let* ((type (mastodon-tl--field 'type note))
-         (fun (cdr (assoc type mastodon-notifications--types-alist))))
-    (when fun (funcall fun note))))
+         (fun (cdr (assoc type mastodon-notifications--types-alist)))
+         (start-pos (point)))
+    (when fun
+      (funcall fun note)
+      (when mastodon-tl--display-media-p
+        (mastodon-media--inline-images start-pos (point))))))
 
 (defun mastodon-notifications--timeline (json)
   "Format JSON in Emacs buffer."
   (mapc #'mastodon-notifications--by-type json)
-  (goto-char (point-min))
-  (when mastodon-tl--display-media-p
-    (mastodon-media--inline-images)))
+  (goto-char (point-min)))
 
 (defun mastodon-notifications--get ()
   "Display NOTIFICATIONS in buffer."

--- a/lisp/mastodon-profile.el
+++ b/lisp/mastodon-profile.el
@@ -76,7 +76,8 @@
                   " ------------\n")
           'success))
         (setq mastodon-tl-update-point (point))
-        (mastodon-tl--timeline json)))    
+        (mastodon-media--inline-images (point-min) (point))
+        (mastodon-tl--timeline json)))
     (mastodon-tl--goto-next-toot)))
 
 (defun mastodon-profile--get-toot-author ()
@@ -112,8 +113,7 @@ FIELD is used to identify regions under 'account"
                      'byline  't
                      'toot-id (cdr (assoc 'id toot)) 'toot-json toot)
                     "\n"))
-          tootv))
-  (mastodon-media--inline-images))
+          tootv)))
 
 (defun mastodon-profile--get-following ()
   "Request a list of those who the user under point follows."

--- a/lisp/mastodon-tl.el
+++ b/lisp/mastodon-tl.el
@@ -635,13 +635,16 @@ the byline that takes one variable. By default it is `mastodon-tl--byline-author
 ACTION-BYLINE is also an optional function for adding an action, such as boosting
 favouriting and following to the byline. It also takes a single function. By default
 it is `mastodon-tl--byline-boosted'"
-  (insert
-   (propertize
-    (concat body
-            (mastodon-tl--byline toot author-byline action-byline))
-    'toot-id    (cdr (assoc 'id toot))
-    'toot-json  toot)
-   "\n\n"))
+  (let ((start-pos (point)))
+    (insert
+     (propertize
+      (concat body
+              (mastodon-tl--byline toot author-byline action-byline))
+      'toot-id    (cdr (assoc 'id toot))
+      'toot-json  toot)
+     "\n\n")
+    (when mastodon-tl--display-media-p
+      (mastodon-media--inline-images start-pos (point)))))
 
 (defun mastodon-tl--toot(toot)
   "Formats TOOT and insertes it into the buffer."
@@ -657,9 +660,7 @@ it is `mastodon-tl--byline-boosted'"
 (defun mastodon-tl--timeline (toots)
   "Display each toot in TOOTS."
   (mapc 'mastodon-tl--toot toots)
-  (goto-char (point-min))
-  (when mastodon-tl--display-media-p
-    (mastodon-media--inline-images)))
+  (goto-char (point-min)))
 
 (defun mastodon-tl--get-update-function (&optional buffer)
   "Get the UPDATE-FUNCTION stored in `mastodon-tl--buffer-spec'"

--- a/test/mastodon-media-tests.el
+++ b/test/mastodon-media-tests.el
@@ -189,7 +189,7 @@
 
         ;; stub for the actual test:
         (stub mastodon-media--load-image-from-url)
-        (mastodon-media--inline-images)
+        (mastodon-media--inline-images (point-min) (point-max))
 
         (should (eq 'loading (get-text-property marker-media-link 'media-state)))
         (should (eq 'invalid-url (get-text-property marker-media-link-bad-url 'media-state)))


### PR DESCRIPTION
Instead of making it search the whole buffer every time to find images to load, give it a range where this work should be done.
We then call this immediately after inserting a single status, notification, ...

There should be no big noticible difference - images might load a tiny bit sooner although I doubt you can see that.
This should be more efficient on large buffers although Alex didn't notice any problems when testing streamed buffers.
We should still do it as it make things easier to understand.  I was always worried about these global operations.