### PR TITLE
More profile work

### DIFF
--- a/README.org
+++ b/README.org
@@ -77,37 +77,38 @@ Opens a =*mastodon-home*= buffer in the major mode so you can see toots. You wil
 
 **** Keybindings
 
-|--------------------------+-----------------------------------------------------------------------------------|
-| Key                      | Action                                                                            |
-|--------------------------+-----------------------------------------------------------------------------------|
-|                          | /In-buffer navigation/                                                            |
-| =<space>=                | Scroll up (i.e. move down to older items)                                         |
-| =<delete>=               | Scroll down (i.e. move up to newer items)                                         |
-| =<=                      | Move to beginning of buffer                                                       |
-| =>=                      | Move to end of buffer                                                             |
-| =j=                      | Go to next item (toot, notification)                                              |
-| =k=                      | Go to previous item (toot, notification)                                          |
-| =<tab>= / =h=            | Go to the next interesting thing that has an action                               |
-| =<S-tab>= / =l=          | Go to the previous interesting thing that has an action                           |
-|                          | /In-buffer actions/                                                               |
-| =?=                      | Open context menu (if =discover= is available)                                    |
-| =c=                      | Toggle the visibility of sensitive text (if there is text with a content warning) |
-| =b=                      | Boost toot under =point=                                                          |
-| =f=                      | Favourite toot under =point=                                                      |
-| =r=                      | Reply to toot under =point=                                                       |
-| =<return>= / =<mouse-2>= | Perform action for the thing under point (or under mouse for =<mouse-2>=) if any  |
-| =n=                      | Compose a new toot                                                                |
-|                          | /Switching to other buffers and quitting/                                         |
-| =N=                      | Open buffer with notifications                                                    |
-| =F=                      | Open federated timeline                                                           |
-| =H=                      | Open home timeline                                                                |
-| =L=                      | Open local timeline                                                               |
-| =U=                      | Open User Profile                                                                 |
-| =t=                      | Open thread buffer for toot under =point=                                         |
-| =T=                      | Prompt for tag and open its timeline                                              |
-| =q=                      | Quit mastodon buffer, leave window open                                           |
-| =Q=                      | Quit mastodon buffer and kill window                                              |
-|--------------------------+-----------------------------------------------------------------------------------|
+|--------------------------+--------------------------------------------------------------------------------------|
+| Key                      | Action                                                                               |
+|--------------------------+--------------------------------------------------------------------------------------|
+|                          | /In-buffer navigation/                                                               |
+| =<space>=                | Scroll up (i.e. move down to older items)                                            |
+| =<delete>=               | Scroll down (i.e. move up to newer items)                                            |
+| =<=                      | Move to beginning of buffer                                                          |
+| =>=                      | Move to end of buffer                                                                |
+| =j=                      | Go to next item (toot, notification)                                                 |
+| =k=                      | Go to previous item (toot, notification)                                             |
+| =<tab>= / =h=            | Go to the next interesting thing that has an action                                  |
+| =<S-tab>= / =l=          | Go to the previous interesting thing that has an action                              |
+|                          | /In-buffer actions/                                                                  |
+| =?=                      | Open context menu (if =discover= is available)                                       |
+| =c=                      | Toggle the visibility of sensitive text (if there is text with a content warning)    |
+| =b=                      | Boost toot under =point=                                                             |
+| =f=                      | Favourite toot under =point=                                                         |
+| =r=                      | Reply to toot under =point=                                                          |
+| =<return>= / =<mouse-2>= | Perform action for the thing under point (or under mouse for =<mouse-2>=) if any     |
+| =n=                      | Compose a new toot                                                                   |
+|                          | /Switching to other buffers and quitting/                                            |
+| =N=                      | Open buffer with notifications                                                       |
+| =F=                      | Open federated timeline                                                              |
+| =H=                      | Open home timeline                                                                   |
+| =L=                      | Open local timeline                                                                  |
+| =U=                      | Open User Profile                                                                    |
+| =P=                      | Open any users profile (free text entry with autocompletion of users in that status) |
+| =t=                      | Open thread buffer for toot under =point=                                            |
+| =T=                      | Prompt for tag and open its timeline                                                 |
+| =q=                      | Quit mastodon buffer, leave window open                                              |
+| =Q=                      | Quit mastodon buffer and kill window                                                 |
+|--------------------------+--------------------------------------------------------------------------------------|
 
 **** Legend
 

--- a/lisp/mastodon-tl.el
+++ b/lisp/mastodon-tl.el
@@ -254,7 +254,7 @@ Optionally start from POS."
                  'mouse-face 'highlight
 		 ;; TODO: Replace url browsing with native profile viewing
 		 'mastodon-tab-stop 'user-handle
-                 'account (cdr (assoc 'account toot))
+                 'account account
 		 'shr-url profile-url
 		 'keymap mastodon-tl--link-keymap
                  'mastodon-handle (concat "@" handle)

--- a/lisp/mastodon-tl.el
+++ b/lisp/mastodon-tl.el
@@ -39,6 +39,9 @@
 (autoload 'mastodon-media--get-media-link-rendering "mastodon-media")
 (autoload 'mastodon-media--inline-images "mastodon-media")
 (autoload 'mastodon-mode "mastodon")
+(autoload 'mastodon-profile--account-from-id "mastodon.el-profile.el")
+(autoload 'mastodon-profile--make-author-buffer "mastodon-profile.el")
+(autoload 'mastodon-profile--search-account-by-handle "mastodon.el-profile.el")
 (defvar mastodon-instance-url)
 (defvar mastodon-toot-timestamp-format)
 (defvar shr-use-fonts)  ;; need to declare it since Emacs24 didn't have this
@@ -72,11 +75,11 @@ width fonts when rendering HTML text"))
   (image-type-available-p 'imagemagick)
   "A boolean value stating whether to show avatars in timelines.")
 
-(defvar mastodon-tl-update-point nil
+(defvar mastodon-tl--update-point nil
   "When updating a mastodon buffer this is where new toots will be inserted.
 
 If nil `(point-min)' is used instead.")
-(make-variable-buffer-local 'mastodon-tl-update-point)
+(make-variable-buffer-local 'mastodon-tl--update-point)
 
 (defvar mastodon-tl--display-media-p t
   "A boolean value stating whether to show media in timelines.")
@@ -941,7 +944,7 @@ from the start if it is nil."
          (json (mastodon-tl--updated-json endpoint id)))
     (when json
       (let ((inhibit-read-only t))
-        (goto-char (or mastodon-tl-update-point (point-min)))
+        (goto-char (or mastodon-tl--update-point (point-min)))
         (funcall update-function json)))))
 
 (defun mastodon-tl--init (buffer-name endpoint update-function)

--- a/lisp/mastodon.el
+++ b/lisp/mastodon.el
@@ -44,13 +44,14 @@
 (autoload 'mastodon-tl--thread "mastodon-tl")
 (autoload 'mastodon-tl--toggle-spoiler-text-in-toot "mastodon-tl")
 (autoload 'mastodon-tl--update "mastodon-tl")
+(autoload 'mastodon-notifications--get "mastodon-notifications")
+(autoload 'mastodon-profile--get-toot-author "mastodon-profile")
+(autoload 'mastodon-profile--make-author-buffer "mastodon-profile")
+(autoload 'mastodon-profile--show-user "mastodon-profile")
 (autoload 'mastodon-toot--compose-buffer "mastodon-toot")
 (autoload 'mastodon-toot--reply "mastodon-toot")
 (autoload 'mastodon-toot--toggle-boost "mastodon-toot")
 (autoload 'mastodon-toot--toggle-favourite "mastodon-toot")
-(autoload 'mastodon-profile--get-next-author "mastodon-profile")
-(autoload 'mastodon-notifications--get "mastodon-notifications")
-(autoload 'mastodon-profile--make-author-buffer "mastodon-profile")
 
 (defgroup mastodon nil
   "Interface with Mastodon."
@@ -85,6 +86,7 @@ Use. e.g. \"%c\" for your locale's date and time format."
     ;; Navigating to other buffers:
     (define-key map (kbd "N") #'mastodon-notifications--get)
     (define-key map (kbd "U") #'mastodon-profile--get-toot-author)
+    (define-key map (kbd "P") #'mastodon-profile--show-user)
     (define-key map (kbd "F") #'mastodon-tl--get-federated-timeline)
     (define-key map (kbd "H") #'mastodon-tl--get-home-timeline)
     (define-key map (kbd "L") #'mastodon-tl--get-local-timeline)


### PR DESCRIPTION
Add an alternative approach to user profile opening.

This way asks the user in the minibuffer for the handle and offering completion for all user handles in the current status but allowing the user to also enter any other handle to browse whichever account they wish.

This also
 - Cleans up some compiler warnings about profile code.
 - Creates a new minor mode for mastodon profile pages.  There we override the 'f' and 'F' keys to show following and followers respectively.
 - Modifies the followers/following pages to look very similar to the regular profile page (with the account header).