### PR TITLE
Tiny fixes to `mastodon-inspect--dump-json-in-buffer`

### DIFF
--- a/lisp/mastodon-inspect.el
+++ b/lisp/mastodon-inspect.el
@@ -44,10 +44,11 @@
 (defun mastodon-inspect--dump-json-in-buffer (name json)
   "Buffer NAME is opened and JSON in printed into it."
   (switch-to-buffer-other-window name)
-  (setf print-level nil
-        print-length nil)
-  (insert (pp json t))
-  (goto-char 1)
+  (erase-buffer)
+  (let ((print-level nil)
+        (print-length nil))
+    (insert (pp json t)))
+  (goto-char (point-min))
   (emacs-lisp-mode)
   (message "success"))
 


### PR DESCRIPTION
- Erase buffer before adding new contents
- Don't globally set `print-level` and `print-length`; just temporarily let them to the locally desired values.