### PR TITLE
Fix the boosting/favouriting of statuses in profiles.

### DIFF
--- a/lisp/mastodon-notifications.el
+++ b/lisp/mastodon-notifications.el
@@ -67,7 +67,7 @@
   "Format for a `mention' NOTE."
   (let ((status (mastodon-tl--field 'status note)))
     (mastodon-tl--insert-status
-     note
+     status
      (mastodon-tl--clean-tabs-and-nl
       (if (mastodon-tl--has-spoiler status)
           (mastodon-tl--spoiler status)
@@ -80,7 +80,9 @@
 (defun mastodon-notifications--follow (note)
   "Format for a `follow' NOTE."
   (mastodon-tl--insert-status
-   note
+   ;; Using reblog with an empty id will mark this as something
+   ;; non-boostable/non-favable.
+   (cons '(reblog (id . nil)) note)
    (propertize "Congratulations, you have a new follower!"
                'face 'default)
    'mastodon-tl--byline-author
@@ -92,7 +94,7 @@
   "Format for a `favourite' NOTE."
   (let ((status (mastodon-tl--field 'status note)))
     (mastodon-tl--insert-status
-     note
+     status
      (mastodon-tl--clean-tabs-and-nl
       (if (mastodon-tl--has-spoiler status)
           (mastodon-tl--spoiler status)
@@ -108,7 +110,7 @@
   "Format for a `boost' NOTE."
   (let ((status (mastodon-tl--field 'status note)))
     (mastodon-tl--insert-status
-     note
+     status
      (mastodon-tl--clean-tabs-and-nl
       (if (mastodon-tl--has-spoiler status)
           (mastodon-tl--spoiler status)

--- a/lisp/mastodon-profile.el
+++ b/lisp/mastodon-profile.el
@@ -45,6 +45,7 @@
 (autoload 'mastodon-tl--render-text "mastodon-tl.el")
 (autoload 'mastodon-tl--set-face "mastodon-tl.el")
 (autoload 'mastodon-tl--timeline "mastodon-tl.el")
+(autoload 'mastodon-tl--toot-id "mastodon-tl")
 
 (defvar mastodon-instance-url)
 (defvar mastodon-tl--buffer-spec)
@@ -190,6 +191,7 @@ FIELD is used to identify regions under 'account"
                        (mastodon-tl--byline-author `((account . ,toot)))
                        'byline  't
                        'toot-id (cdr (assoc 'id toot))
+                       'base-toot-id (mastodon-tl--toot-id toot)
                        'toot-json toot))
               (mastodon-media--inline-images start-pos (point))
               (insert "\n"

--- a/lisp/mastodon-tl.el
+++ b/lisp/mastodon-tl.el
@@ -643,8 +643,9 @@ it is `mastodon-tl--byline-boosted'"
      (propertize
       (concat body
               (mastodon-tl--byline toot author-byline action-byline))
-      'toot-id    (cdr (assoc 'id toot))
-      'toot-json  toot)
+      'toot-id      (cdr (assoc 'id toot))
+      'base-toot-id (mastodon-tl--toot-id toot)
+      'toot-json    toot)
      "\n\n")
     (when mastodon-tl--display-media-p
       (mastodon-media--inline-images start-pos (point)))))

--- a/lisp/mastodon-toot.el
+++ b/lisp/mastodon-toot.el
@@ -89,7 +89,9 @@ Remove MARKER if REMOVE is non-nil, otherwise add it."
 (defun mastodon-toot--toggle-boost ()
   "Boost/unboost toot at `point'."
   (interactive)
-  (let* ((byline-region (mastodon-tl--find-property-range 'byline (point)))
+  (let* ((has-id (mastodon-tl--property 'base-toot-id))
+         (byline-region (when has-id
+                          (mastodon-tl--find-property-range 'byline (point))))
          (id (when byline-region
                (mastodon-tl--as-string (mastodon-tl--property 'base-toot-id))))
          (boosted (when byline-region
@@ -113,7 +115,9 @@ Remove MARKER if REMOVE is non-nil, otherwise add it."
 (defun mastodon-toot--toggle-favourite ()
   "Favourite/unfavourite toot at `point'."
   (interactive)
-  (let* ((byline-region (mastodon-tl--find-property-range 'byline (point)))
+  (let* ((has-id (mastodon-tl--property 'base-toot-id))
+         (byline-region (when has-id
+                          (mastodon-tl--find-property-range 'byline (point))))
          (id (when byline-region
                (mastodon-tl--as-string (mastodon-tl--property 'base-toot-id))))
          (faved (when byline-region

--- a/lisp/mastodon-toot.el
+++ b/lisp/mastodon-toot.el
@@ -40,6 +40,7 @@
 (autoload 'mastodon-tl--field "mastodon-tl")
 (autoload 'mastodon-tl--goto-next-toot "mastodon-tl")
 (autoload 'mastodon-tl--property "mastodon-tl")
+(autoload 'mastodon-tl--find-property-range "mastodon-tl")
 (autoload 'mastodon-toot "mastodon")
 
 (defvar mastodon-toot--reply-to-id nil
@@ -77,7 +78,7 @@ Remove MARKER if REMOVE is non-nil, otherwise add it."
 
 (defun mastodon-toot--action (action callback)
   "Take ACTION on toot at point, then execute CALLBACK."
-  (let* ((id (mastodon-tl--property 'toot-id))
+  (let* ((id (mastodon-tl--property 'base-toot-id))
          (url (mastodon-http--api (concat "statuses/"
                                          (mastodon-tl--as-string id)
                                          "/"
@@ -90,7 +91,7 @@ Remove MARKER if REMOVE is non-nil, otherwise add it."
   (interactive)
   (let* ((byline-region (mastodon-tl--find-property-range 'byline (point)))
          (id (when byline-region
-               (mastodon-tl--as-string (mastodon-tl--property 'toot-id))))
+               (mastodon-tl--as-string (mastodon-tl--property 'base-toot-id))))
          (boosted (when byline-region
                     (get-text-property (car byline-region) 'boosted-p)))
          (action (if boosted "unreblog" "reblog"))
@@ -114,7 +115,7 @@ Remove MARKER if REMOVE is non-nil, otherwise add it."
   (interactive)
   (let* ((byline-region (mastodon-tl--find-property-range 'byline (point)))
          (id (when byline-region
-               (mastodon-tl--as-string (mastodon-tl--property 'toot-id))))
+               (mastodon-tl--as-string (mastodon-tl--property 'base-toot-id))))
          (faved (when byline-region
                   (get-text-property (car byline-region) 'favourited-p)))
          (action (if faved "unfavourite" "favourite"))


### PR DESCRIPTION
(Favouriting itself is still hard since we have clobbered the 'f' keybinding, but if you bind it to something else or invoke it via `M-x mastodon-toot--toggle-favourite` then at least it works.)
This also changes the regular boosting/favoriting behavior.  Before we would boost/fav a boost or fav instead of the actual toot that was boosted/faved.  With this change we always boost/fav the base toot.

To do this we now keep a second toot id (with the base toot) in the byline's properities.  (For regular statuses 'toot-id and 'base-toot-id will be identical.)

Once we have that we can also improve boosting/faving in notifications.  E.g. a new follower notification has nothing to boost/fav so if we tweak things that those don't have a `base-too-id` then things work.
(While we fix things there we can also ensure that we show the actual toot for boost and fav notifications - I am surprised this worked before.)