### PR TITLE
Make most GET calls in the api async.

### DIFF
--- a/lisp/mastodon-notifications.el
+++ b/lisp/mastodon-notifications.el
@@ -132,15 +132,20 @@
       (when mastodon-tl--display-media-p
         (mastodon-media--inline-images start-pos (point))))))
 
-(defun mastodon-notifications--timeline (json)
+(defun mastodon-notifications--timeline (json insert-at-end-p)
   "Format JSON in Emacs buffer."
-  (mapc #'mastodon-notifications--by-type json)
-  (goto-char (point-min)))
+  (let ((insert-point (if insert-at-end-p
+                          (point-max)
+                        (point-min))))
+    (goto-char insert-point)
+    (mapc #'mastodon-notifications--by-type json)
+    (goto-char insert-point)))
 
 (defun mastodon-notifications--get ()
   "Display NOTIFICATIONS in buffer."
   (interactive)
   (mastodon-tl--init
+   "Notifications"
    "*mastodon-notifications*"
    "notifications"
    'mastodon-notifications--timeline))

--- a/lisp/mastodon-toot.el
+++ b/lisp/mastodon-toot.el
@@ -363,6 +363,7 @@ If REPLY-TO-ID is provided, set the MASTODON-TOOT--REPLY-TO-ID var."
 
 (defun mastodon-toot--update-status-fields (&rest args)
   "Update the status fields in the header based on the current state."
+  (ignore args)
   (let ((inhibit-read-only t)
         (header-region (mastodon-tl--find-property-range 'toot-post-header
                                                          (point-min)))

--- a/lisp/mastodon.el
+++ b/lisp/mastodon.el
@@ -135,6 +135,15 @@ Use. e.g. \"%c\" for your locale's date and time format."
   '((t :inherit success))
   "Face used for content warning.")
 
+(defface mastodon-title-face
+  '((t :inherit highlight :weight bold :height 2.0))
+  "Face for buffer titles/headings.")
+
+(defface mastodon-temp-message-face
+  '((t :inherit highlight :weight bold
+       :foreground "black" :backgroud "red"))
+  "Face for temporary, in-buffer messages.")
+
 ;;;###autoload
 (defun mastodon ()
   "Connect Mastodon client to `mastodon-instance-url' instance."

--- a/test/mastodon-notifications-test.el
+++ b/test/mastodon-notifications-test.el
@@ -181,13 +181,6 @@
              (statuses_count . 101)
              (note . "E"))))
 
-(ert-deftest notification-get ()
-  "Ensure get request format for notifictions is accurate."
-  (let ((mastodon-instance-url "https://instance.url"))
-    (with-mock
-      (mock (mastodon-http--get-json "https://instance.url/api/v1/notifications"))
-      (mastodon-notifications--get))))
-
 (defun mastodon-notifications--test-type (fun sample)
   "Test notification draw functions.
 

--- a/test/mastodon-tl-tests.el
+++ b/test/mastodon-tl-tests.el
@@ -121,33 +121,6 @@
   (let ((id 1000))
       (should (string= (mastodon-tl--as-string id) (number-to-string id)))))
 
-(ert-deftest more-json ()
-  "Should request toots older than max_id."
-  (let ((mastodon-instance-url "https://instance.url"))
-    (with-mock
-      (mock (mastodon-http--get-json "https://instance.url/api/v1/timelines/foo?max_id=12345"))
-      (mastodon-tl--more-json "timelines/foo" 12345))))
-
-(ert-deftest more-json-id-string ()
-  "Should request toots older than max_id.
-
-`mastodon-tl--more-json' should accept and id that is either
-a string or a numeric."
-  (let ((mastodon-instance-url "https://instance.url"))
-    (with-mock
-      (mock (mastodon-http--get-json "https://instance.url/api/v1/timelines/foo?max_id=12345"))
-      (mastodon-tl--more-json "timelines/foo" "12345"))))
-
-(ert-deftest update-json-id-string ()
-  "Should request toots more recent than since_id.
-
-`mastodon-tl--updated-json' should accept and id that is either
-a string or a numeric."
-  (let ((mastodon-instance-url "https://instance.url"))
-    (with-mock
-      (mock (mastodon-http--get-json "https://instance.url/api/v1/timelines/foo?since_id=12345"))
-      (mastodon-tl--updated-json "timelines/foo" "12345"))))
-
 (ert-deftest mastodon-tl--relative-time-description ()
   "Should format relative time as expected"
   (cl-labels ((minutes (n) (* n 60))


### PR DESCRIPTION
This stops mastodon from blocking all of emacs when you have a slow connection.

Since the display of a longer timeline could also be quite slow we now to the insertions in reverse order (i.e. starting from oldest) and redisplay after each toot. That gives the user some nice visual feedback as the toots are flowing into and down the buffer one by one.

I failed to update the mocking in a small number of tests which therefore had to be removed. I'll need to learn more about the mocking and stubbing in ert-tests to see if we can get this working if part of the arguments we want to match are very dynamic things like buffers.