### PR TITLE
Add ability to set toot visibility

### DIFF
--- a/README.org
+++ b/README.org
@@ -136,15 +136,21 @@ Authentication stores your access token in the =mastodon-auth--token=
 variable. It is not stored on your filesystem, so you will have to 
 re-authenticate when you close/reopen Emacs.
 
+**** Customization
+The default toot visibility can be changed by setting or customizing the =mastodon-toot--default-visibility= variable. Valid values are ="public"=, ="unlisted"=, ="private"=, or =direct=.
+
+Toot visibility can also be changed on a per-toot basis from the new toot buffer.
+
 **** Keybindings
 
-|-----------+---------------------|
-| Key       | Action              |
-|-----------+---------------------|
-| =C-c C-c= | Send toot           |
-| =C-c C-k= | Cancel toot         |
-| =C-c C-w= | Add content warning |
-|-----------+---------------------|
+|-----------+------------------------|
+| Key       | Action                 |
+|-----------+------------------------|
+| =C-c C-c= | Send toot              |
+| =C-c C-k= | Cancel toot            |
+| =C-c C-w= | Add content warning    |
+| =C-c C-v= | Change toot visibility |
+|-----------+------------------------|
 
 ** Roadmap
 

--- a/lisp/mastodon-toot.el
+++ b/lisp/mastodon-toot.el
@@ -32,9 +32,16 @@
 (defvar mastodon-instance-url)
 (defvar mastodon-toot--content-warning nil)
 (defvar mastodon-toot--visibility)
-(defvar mastodon-toot--default-visibility "public"
+(defcustom mastodon-toot--default-visibility "public"
   "Default visiblity for toots.
-Valid values: \"public\", \"unlisted\", \"private\", \"direct\".")
+Valid values: \"public\", \"unlisted\", \"private\", \"direct\"."
+  :tag "Default Toot Visibility"
+  :group 'mastodon
+  :type '(radio (const :tag "Public" "public")
+                (const :tag "Unlisted" "unlisted")
+                (const :tag "Private" "private")
+                (const :tag "Direct" "direct")))
+
 (setq mastodon-toot--visibility mastodon-toot--default-visibility)
 
 (autoload 'mastodon-auth--user-acct "mastodon-auth")

--- a/lisp/mastodon-toot.el
+++ b/lisp/mastodon-toot.el
@@ -152,7 +152,7 @@ Set `mastodon-toot--visiblity' to `mastodon-toot--default-visiblity' (default \"
   (kill-buffer-and-window)
   (setq mastodon-toot--reply-to-id     nil
         mastodon-toot--content-warning nil
-	mastodon-toot--visibility      mastodon-toot--default-visibility))
+        mastodon-toot--visibility      mastodon-toot--default-visibility))
 
 (defun mastodon-toot--cancel ()
   "Kill new-toot buffer/window. Does not POST content to Mastodon."
@@ -171,9 +171,9 @@ Set `mastodon-toot--visiblity' to `mastodon-toot--default-visiblity' (default \"
   "Sets the visiblity of the next toot"
   (interactive
    (list (completing-read "Visiblity: " '("public"
-					  "unlisted"
-					  "private"
-					  "direct"))))
+                                          "unlisted"
+                                          "private"
+                                          "direct"))))
   (setq mastodon-toot--visibility visibility)
   (message "Visibility set to %s" visibility))
 
@@ -188,7 +188,7 @@ Set `mastodon-toot--visiblity' to `mastodon-toot--default-visiblity' (default \"
                  ("in_reply_to_id" . ,mastodon-toot--reply-to-id)
                  ("sensitive" . ,(when mastodon-toot--content-warning
                                    (symbol-name t)))
-		 ("visibility" . ,mastodon-toot--visibility)
+                 ("visibility" . ,mastodon-toot--visibility)
                  ("spoiler_text" . ,spoiler))))
     (mastodon-toot--kill)
     (let ((response (mastodon-http--post endpoint args nil)))


### PR DESCRIPTION
This adds the ability to change the visibility of toots. The default visibility is `public`, but that can be changed by setting the variable `mastodon-toot--default-visibility`.