### PR TITLE
Explicitly require json.el in files where we dynamically bind its vars.

### DIFF
--- a/lisp/mastodon-auth.el
+++ b/lisp/mastodon-auth.el
@@ -31,6 +31,7 @@
 
 (require 'plstore)
 (require 'auth-source)
+(require 'json)
 
 (autoload 'mastodon-client "mastodon-client")
 (autoload 'mastodon-http--api "mastodon-http")

--- a/lisp/mastodon-client.el
+++ b/lisp/mastodon-client.el
@@ -30,6 +30,8 @@
 ;;; Code:
 
 (require 'plstore)
+(require 'json)
+
 (defvar mastodon-instance-url)
 (autoload 'mastodon-http--api "mastodon-http")
 (autoload 'mastodon-http--post "mastodon-http")


### PR DESCRIPTION
As pointed out in issue #211 the compiler actually warned the user about `json-array-type` etc. being unused lexical vars.

Let's hope that this fixes the errors reported with reading json.