### PR TITLE
Refactor #220

### DIFF
--- a/README.org
+++ b/README.org
@@ -23,7 +23,7 @@ Or, with =use-package=:
 
 #+BEGIN_SRC emacs-lisp
   (use-package mastodon
-    :load-path "/path/to/mastodon.el/lisp")
+    :ensure t)
 #+END_SRC
 
 *** MELPA
@@ -56,9 +56,17 @@ if you have Discover, add the following to your Emacs init configuration:
 
 #+BEGIN_SRC emacs-lisp
   (require 'mastodon-discover)
-  (with-eval-after-load 'mastodon (mastodon-discover--init))
+  (with-eval-after-load 'mastodon (mastodon-discover))
 #+END_SRC
 
+Or, with =use-package=:
+
+#+BEGIN_SRC emacs-lisp
+  (use-package mastodon
+    :ensure t
+    :config
+    (mastodon-discover))
+#+END_SRC
 
 ** Usage
 *** 2 Factor Auth
@@ -159,7 +167,6 @@ Toot visibility can also be changed on a per-toot basis from the new toot buffer
 | =C-c C-w= | Add content warning    |
 | =C-c C-v= | Change toot visibility |
 |-----------+------------------------|
->>>>>>> Make default visibility customizable; add documentation.
 
 ** Roadmap
 

--- a/lisp/mastodon-discover.el
+++ b/lisp/mastodon-discover.el
@@ -31,39 +31,39 @@
 ;; See the README file for how to use this.
 
 ;;; Code:
-(require 'discover)
 
-(defun mastodon-discover--init ()
-  "Plug Mastodon functionality into discover."
+(defun mastodon-discover ()
+  "Plug Mastodon functionality into `discover'."
   (interactive)
-  (discover-add-context-menu
-   :bind "?"
-   :mode 'mastodon-mode
-   :mode-hook 'mastodon-mode-hook
-   :context-menu '(mastodon
-                   (description "Mastodon feed viewer")
-                   (actions
-                    ("Toots"
-                     ("A" "Author" mastodon-profile--get-toot-author)
-                     ("b" "Boost" mastodon-toot--boost)
-                     ("c" "Toggle content" mastodon-tl--toggle-spoiler-text-in-toot)
-                     ("f" "Favourite" mastodon-toot--favourite)
-                     ("j" "Next" mastodon-tl--goto-next-toot)
-                     ("k" "Prev" mastodon-tl--goto-prev-toot)
-                     ("n" "Send" mastodon-toot)
-                     ("r" "Reply" mastodon-toot--reply)
-                     ("t" "Thread" mastodon-tl--thread)
-                     ("u" "Update" mastodon-tl--update)
-                     ("U" "Users" mastodon-profile--show-user))
-                    ("Timelines"
-                     ("F" "Federated" mastodon-tl--get-federated-timeline)
-                     ("H" "Home" mastodon-tl--get-home-timeline)
-                     ("L" "Local" mastodon-tl--get-local-timeline)
-                     ("N" "Notifications" mastodon-notifications--get)
-                     ("T" "Tag" mastodon-tl--get-tag-timeline))
-                    ("Quit"
-                     ("q" "Quit mastodon buffer. Leave window open." kill-this-buffer)
-                     ("Q" "Quit mastodon buffer and kill window." kill-buffer-and-window))))))
+  (when (require 'discover nil :noerror)
+    (discover-add-context-menu
+     :bind "?"
+     :mode 'mastodon-mode
+     :mode-hook 'mastodon-mode-hook
+     :context-menu '(mastodon
+                     (description "Mastodon feed viewer")
+                     (actions
+                      ("Toots"
+                       ("A" "Author" mastodon-profile--get-toot-author)
+                       ("b" "Boost" mastodon-toot--boost)
+                       ("c" "Toggle content" mastodon-tl--toggle-spoiler-text-in-toot)
+                       ("f" "Favourite" mastodon-toot--favourite)
+                       ("j" "Next" mastodon-tl--goto-next-toot)
+                       ("k" "Prev" mastodon-tl--goto-prev-toot)
+                       ("n" "Send" mastodon-toot)
+                       ("r" "Reply" mastodon-toot--reply)
+                       ("t" "Thread" mastodon-tl--thread)
+                       ("u" "Update" mastodon-tl--update)
+                       ("U" "Users" mastodon-profile--show-user))
+                      ("Timelines"
+                       ("F" "Federated" mastodon-tl--get-federated-timeline)
+                       ("H" "Home" mastodon-tl--get-home-timeline)
+                       ("L" "Local" mastodon-tl--get-local-timeline)
+                       ("N" "Notifications" mastodon-notifications--get)
+                       ("T" "Tag" mastodon-tl--get-tag-timeline))
+                      ("Quit"
+                       ("q" "Quit mastodon buffer. Leave window open." kill-this-buffer)
+                       ("Q" "Quit mastodon buffer and kill window." kill-buffer-and-window)))))))
 
 (provide 'mastodon-discover)
 ;;; mastodon-discover.el ends here

--- a/lisp/mastodon.el
+++ b/lisp/mastodon.el
@@ -52,6 +52,7 @@
 (autoload 'mastodon-toot--reply "mastodon-toot")
 (autoload 'mastodon-toot--toggle-boost "mastodon-toot")
 (autoload 'mastodon-toot--toggle-favourite "mastodon-toot")
+(autoload 'mastodon-discover "mastodon-discover")
 
 (defgroup mastodon nil
   "Interface with Mastodon."


### PR DESCRIPTION
- Change `mastodon-discover--init` to `mastodon-discover`
- Wrap in `when` statement to make `use-package` easier
- Update README with `use-package` instructions for `mastodon-discover`