### PR TITLE
Rewrite `mastodon-auth--access-token` so it handles errors.

### DIFF
--- a/lisp/mastodon-auth.el
+++ b/lisp/mastodon-auth.el
@@ -124,13 +124,19 @@ Reads and/or stores secres in `MASTODON-AUTH-SOURCE-FILE'."
   "Return the access token to use with the current `mastodon-instance-url'.
 
 Generate token and set if none known yet."
-  (let ((token
-         (cdr (assoc mastodon-instance-url mastodon-auth--token-alist))))
-    (unless token 
-      (let ((json (mastodon-auth--get-token)))
-        (setq token (plist-get json :access_token))
-        (push (cons mastodon-instance-url token) mastodon-auth--token-alist)))
-    token))
+  (if-let ((token (cdr (assoc mastodon-instance-url mastodon-auth--token-alist))))
+      token
+
+    (pcase (mastodon-auth--get-token)
+      ((let token (lambda (response) (plist-get response :access_token)))
+
+       (cdar (push (cons mastodon-instance-url token)
+                   mastodon-auth--token-alist)))
+
+      (`(:error ,class :error_description ,error)
+       (error "mastodon-auth--access-token: %s: %s" class error))
+
+      (_ (error "Unknown response from mastodon-auth--get-token!")))))
 
 (defun mastodon-auth--get-account-name ()
   "Request user credentials and return an account name."


### PR DESCRIPTION
Currently, `mastodon-auth--access-token` unconditionally returns the
value of the `:access_token` key from the response of
`(mastodon-auth--get-token)`.  This causes problems when there was an
error getting the token, for example, if you enter the wrong
password.  If a token couldn’t be retrieved, the JSON looks like:

    (:error "invalid_grant"
     :error_description "The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.")

Since there is no `:access_token` key, `mastodon-auth--access-token`
returns `nil`, which results in a broken header in the next request:

    Authorization: Bearer

Which causes the whole thing to freeze Emacs until you mash `C-g`.

This commit rewrites the function to handle that case; to explicitly
signal an error for *any* response that isn’t expected; to use
`if-let`, which allows the temporary `token` variable to be
eliminated; and to use `pcase` to determine what kind of response was
received.