### PR TITLE
Rewrite `mastodon-auth--access-token` so it handles errors.

### DIFF
--- a/lisp/mastodon-auth--test.el
+++ b/lisp/mastodon-auth--test.el
@@ -1,0 +1,47 @@
+;;; mastodon-auth--test.el --- Tests for mastodon-auth  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2020  Ian Eure
+
+;; Author: Ian Eure <ian@retrospec.tv>
+;; Version: 0.9.0
+;; Homepage: https://github.com/jdenen/mastodon.el
+;; Package-Requires: ((emacs "24.4"))
+
+;; This file is not part of GNU Emacs.
+
+;; This file is part of mastodon.el.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; mastodon-auth--test.el provides ERT tests for mastodon-auth.el
+
+;;; Code:
+
+(require 'ert)
+
+(ert-deftest mastodon-auth--handle-token-response--good ()
+  (should (string= "foo" (mastodon-auth--handle-token-response '(:access_token "foo" :token_type "Bearer" :scope "read write follow" :created_at 0)))))
+
+(ert-deftest mastodon-auth--handle-token-response--unknown ()
+  :expected-result :failed
+  (mastodon-auth--handle-token-response '(:herp "derp")))
+
+(ert-deftest mastodon-auth--handle-token-response--failure ()
+  :expected-result :failed
+  (mastodon-auth--handle-token-response '(:error "invalid_grant" :error_description "The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.")))
+
+(provide 'mastodon-auth--test)
+;;; mastodon-auth--test.el ends here


### PR DESCRIPTION
Currently, `mastodon-auth--access-token` unconditionally returns the
value of the `:access_token` key from the response of
`(mastodon-auth--get-token)`.  This causes problems when there was an
error getting the token, for example, if you enter the wrong
password.  If a token couldn’t be retrieved, the JSON looks like:

    (:error "invalid_grant"
     :error_description "The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.")

Since there is no `:access_token` key, `mastodon-auth--access-token`
returns `nil`, which results in a broken header in the next request:

    Authorization: Bearer

Which causes the whole thing to freeze Emacs until you mash `C-g`.

This commit rewrites the function to handle that case; to explicitly
signal an error for *any* response that isn’t expected; to use
`if-let`, which allows the temporary `token` variable to be
eliminated; uses `pcase` to determine what kind of response was
received; and adds ERT tests for all these cases.