### PR TITLE
Implement clickable images with shr-browse-image.

### DIFF
--- a/lisp/mastodon-discover.el
+++ b/lisp/mastodon-discover.el
@@ -50,7 +50,9 @@
                        ("f" "Favourite" mastodon-toot--favourite)
                        ("n" "Next" mastodon-tl--goto-next-toot)
                        ("p" "Prev" mastodon-tl--goto-prev-toot)
-                       ("t" "Toot" mastodon-toot)
+                       ("TAB" "Next link item" mastodon-tl--next-tab-item)
+                       ("S-TAB" "Prev link item" mastodon-tl--previous-tab-item)
+                       ("t" "New toot" mastodon-toot)
                        ("r" "Reply" mastodon-toot--reply)
                        ("u" "Update" mastodon-tl--update)
                        ("P" "Users" mastodon-profile--show-user)
@@ -61,6 +63,15 @@
                        ("H" "Home" mastodon-tl--get-home-timeline)
                        ("L" "Local" mastodon-tl--get-local-timeline)
                        ("N" "Notifications" mastodon-notifications--get))
+                      ("Images"
+                       ("RET/i" "Load full image in browser" 'shr-browse-image)
+                       ("r" "rotate" 'image-rotate)
+                       ("+" "zoom in" 'image-increase-size)
+                       ("-" "zoom out" 'image-decrease-size)
+                       ("u" "copy URL" 'shr-maybe-probe-and-copy-url))
+                      ("Profile view"
+                       ("o" "Show following" mastodon-profile--open-following)
+                       ("O" "Show followers" mastodon-profile--open-followers))
                       ("Quit"
                        ("q" "Quit mastodon buffer. Leave window open." kill-this-buffer)
                        ("Q" "Quit mastodon buffer and kill window." kill-buffer-and-window)))))))

--- a/lisp/mastodon-media.el
+++ b/lisp/mastodon-media.el
@@ -262,14 +262,20 @@ replacing them with the referenced image."
                                  t image-options))
      " ")))
 
-(defun mastodon-media--get-media-link-rendering (media-url)
+(defun mastodon-media--get-media-link-rendering (media-url &optional full-remote-url)
   "Returns the string to be written that renders the image at MEDIA-URL."
   (concat
    (propertize "[img]"
                'media-url media-url
                'media-state 'needs-loading
                'media-type 'media-link
-               'display (create-image mastodon-media--generic-broken-image-data nil t))
+               'display (create-image mastodon-media--generic-broken-image-data nil t)
+               'mouse-face 'highlight
+               'mastodon-tab-stop 'image ; for do-link-action-at-point
+               'image-url full-remote-url ; for shr-browse-image
+               'keymap mastodon-tl--shr-image-map-replacement
+               'help-echo (concat "RET/i: load full image (prefix: copy URL), +/-: zoom, r: rotate, o: save preview")
+               )
    " "))
 
 (provide 'mastodon-media)

--- a/lisp/mastodon-tl.el
+++ b/lisp/mastodon-tl.el
@@ -124,6 +124,9 @@ types of mastodon links and not just shr.el-generated ones.")
     ;; version that knows about more types of links.
     (define-key map [remap shr-next-link] 'mastodon-tl--next-tab-item)
     (define-key map [remap shr-previous-link] 'mastodon-tl--previous-tab-item)
+    ;; browse-url loads the preview only, we want browse-image
+    ;; on RET to browse full sized image URL
+    (define-key map [remap shr-browse-url] 'shr-browse-image)
     (keymap-canonicalize map))
   "The keymap to be set for shr.el generated image links.
 
@@ -541,6 +544,7 @@ LINK-TYPE is the type of link to produce."
      'help-echo help-text)))
 
 (defun mastodon-tl--do-link-action-at-point (position)
+  ;; called by RET
   (interactive "d")
   (let ((link-type (get-text-property position 'mastodon-tab-stop)))
     (cond ((eq link-type 'content-warning)
@@ -565,6 +569,7 @@ LINK-TYPE is the type of link to produce."
            (error "unknown link type %s" link-type)))))
 
 (defun mastodon-tl--do-link-action (event)
+  ;; called by mouse click
   (interactive "e")
   (mastodon-tl--do-link-action-at-point (posn-point (event-end event))))
 
@@ -610,17 +615,18 @@ message is a link which unhides/hides the main body."
          (media-string (mapconcat
                         (lambda (media-attachement)
                           (let ((preview-url
-                                 (cdr (assoc 'preview_url media-attachement))))
+                                 (cdr (assoc 'preview_url media-attachement)))
+                                (remote-url
+                                 (cdr (assoc 'remote_url media-attachement))))
                             (if mastodon-tl--display-media-p
                                 (mastodon-media--get-media-link-rendering
-                                 preview-url)
+                                 preview-url remote-url) ; 2nd arg for shr-browse-url
                               (concat "Media::" preview-url "\n"))))
                         media-attachements "")))
     (if (not (and mastodon-tl--display-media-p
                   (equal media-string "")))
         (concat "\n" media-string)
       "")))
-
 
 (defun mastodon-tl--content (toot)
   "Retrieve text content from TOOT."


### PR DESCRIPTION
images are tab stops. click or RET runs shr-browse-image, prefix arg or 'u' copies the URL.

images use the mastodon-tl--shr-image-map-replacement for extra functions like zoom
image, save image, rotate image, etc.