### PR TITLE
Fix: make after-change-functions buffer local.

### DIFF
--- a/lisp/mastodon-toot.el
+++ b/lisp/mastodon-toot.el
@@ -401,6 +401,7 @@ If REPLY-TO-ID is provided, set the MASTODON-TOOT--REPLY-TO-ID var."
     (when (not buffer-exists)
       (mastodon-toot--display-docs-and-status-fields)
       (mastodon-toot--setup-as-reply reply-to-user reply-to-id))
+    (make-local-variable 'after-change-functions)
     (push #'mastodon-toot--update-status-fields after-change-functions)
     (mastodon-toot--update-status-fields)
     (mastodon-toot-mode t)))


### PR DESCRIPTION
See issue #218 — we mistakenly modified the global value and `mastodon-toot--update-status-fields` makes no sense outside the toot compose buffer.